### PR TITLE
Implement accumulator pattern

### DIFF
--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -51,6 +52,23 @@ type Component interface {
 	WatchTypes() []runtime.Object
 	IsReconcilable(*ComponentContext) bool
 	Reconcile(*ComponentContext) (reconcile.Result, error)
+}
+
+// GathererComponent enables the accumulator pattern on Reconciler.
+type GathererComponent interface {
+	Component
+	// WatchPredicateFuncs determines if a handler.MapObject should trigger a
+	// reconcile request inferred from Top's metav1.Object interface.
+	//
+	// Note: Reconcile request are limited to those inferrable by Top's
+	// metav1.Object by the NewReconciler in order to forbid components to
+	// generate side effects other than by their Reconcile function itself.
+	//
+	// Insofar, the semantics are different from it's underlying
+	// EnqueueRequestsFromMapFunc while implementing a superset of
+	// EnqueueRequestForOwner semantics. You should avoid to reimplement the
+	// latter through this function.
+	WatchPredicateFuncs() predicate.Funcs
 }
 
 type Status interface{}


### PR DESCRIPTION
_Note: This is more a "Note to myself" and a "Note to @coderanger" rather than a true intent for requesting acceptance. Just close it and have it in this repo's PR inventory in case you may find it useful later on._

A GathererComponent implements WatchPredicateFuncs()
IsGatherable acts upon a *handler.MapObject to determin if Top object
should be reconciled.

It uses the same WatchTypes as used for the OwnerReference, so WatchPredicateFuncs
should take care to avoid reimplementing a OnwerReference semantic.