### PR TITLE
Move DjangoUser from summon.ridecell.io to db.ridecell.io.

### DIFF
--- a/pkg/apis/db/v1beta1/djangouser_types.go
+++ b/pkg/apis/db/v1beta1/djangouser_types.go
@@ -20,24 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type SecretRef struct {
-	Name string `json:"name"`
-	Key  string `json:"key,omitempty"`
-}
-
-type DatabaseConnection struct {
-	Host              string    `json:"host"`
-	Port              uint16    `json:"port,omitempty"`
-	Username          string    `json:"username"`
-	PasswordSecretRef SecretRef `json:"passwordSecretRef"`
-	Database          string    `json:"database,omitempty"`
-}
-
 // DjangoUserSpec defines the desired state of DjangoUser
 type DjangoUserSpec struct {
 	Email          string             `json:"email"`
 	PasswordSecret string             `json:"passwordSecret,omitempty"`
-	Database       DatabaseConnection `json:"database"`
+	Database       PostgresConnection `json:"database"`
 	FirstName      string             `json:"firstName,omitempty"`
 	LastName       string             `json:"lastName,omitempty"`
 	Active         bool               `json:"active"`

--- a/pkg/apis/db/v1beta1/djangouser_types_test.go
+++ b/pkg/apis/db/v1beta1/djangouser_types_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/test_helpers"
 )
 
@@ -44,13 +44,13 @@ var _ = Describe("DjangoUser types", func() {
 			Name:      "foo",
 			Namespace: helpers.Namespace,
 		}
-		created := &summonv1beta1.DjangoUser{
+		created := &dbv1beta1.DjangoUser{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: helpers.Namespace,
 			},
 		}
-		fetched := &summonv1beta1.DjangoUser{}
+		fetched := &dbv1beta1.DjangoUser{}
 		err := c.Create(context.TODO(), created)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -66,13 +66,13 @@ var _ = Describe("DjangoUser types", func() {
 			Name:      "foo",
 			Namespace: helpers.Namespace,
 		}
-		created := &summonv1beta1.DjangoUser{
+		created := &dbv1beta1.DjangoUser{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: helpers.Namespace,
 			},
 		}
-		fetched := &summonv1beta1.DjangoUser{}
+		fetched := &dbv1beta1.DjangoUser{}
 		err := c.Create(context.TODO(), created)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/apis/db/v1beta1/status.go
+++ b/pkg/apis/db/v1beta1/status.go
@@ -45,3 +45,16 @@ func (po *PostgresOperatorDatabase) SetErrorStatus(errorMsg string) {
 	po.Status.Status = StatusError
 	po.Status.Message = errorMsg
 }
+
+func (s *DjangoUser) GetStatus() components.Status {
+	return s.Status
+}
+
+func (s *DjangoUser) SetStatus(status components.Status) {
+	s.Status = status.(DjangoUserStatus)
+}
+
+func (s *DjangoUser) SetErrorStatus(errorMsg string) {
+	s.Status.Status = StatusError
+	s.Status.Message = errorMsg
+}

--- a/pkg/apis/db/v1beta1/types.go
+++ b/pkg/apis/db/v1beta1/types.go
@@ -25,6 +25,9 @@ const (
 	StatusError = "Error"
 )
 
+// Alias for simplicity.
+type SecretRef = helpers.SecretRef
+
 // Connection details for a Postgres database.
 type PostgresConnection struct {
 	Host              string            `json:"host"`

--- a/pkg/apis/summon/v1beta1/status.go
+++ b/pkg/apis/summon/v1beta1/status.go
@@ -32,16 +32,3 @@ func (s *SummonPlatform) SetErrorStatus(errorMsg string) {
 	s.Status.Status = StatusError
 	s.Status.Message = errorMsg
 }
-
-func (s *DjangoUser) GetStatus() components.Status {
-	return s.Status
-}
-
-func (s *DjangoUser) SetStatus(status components.Status) {
-	s.Status = status.(DjangoUserStatus)
-}
-
-func (s *DjangoUser) SetErrorStatus(errorMsg string) {
-	s.Status.Status = StatusError
-	s.Status.Message = errorMsg
-}

--- a/pkg/controller/djangouser/components/components_suite_test.go
+++ b/pkg/controller/djangouser/components/components_suite_test.go
@@ -25,11 +25,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/Ridecell/ridecell-operator/pkg/apis"
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
 )
 
-var instance *summonv1beta1.DjangoUser
+var instance *dbv1beta1.DjangoUser
 var ctx *components.ComponentContext
 
 func TestComponents(t *testing.T) {
@@ -40,7 +40,7 @@ func TestComponents(t *testing.T) {
 
 var _ = ginkgo.BeforeEach(func() {
 	// Set up default-y values for tests to use if they want.
-	instance = &summonv1beta1.DjangoUser{
+	instance = &dbv1beta1.DjangoUser{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo.example.com", Namespace: "default"},
 	}
 	ctx = components.NewTestContext(instance, nil)

--- a/pkg/controller/djangouser/components/database_test.go
+++ b/pkg/controller/djangouser/components/database_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	djangousercomponents "github.com/Ridecell/ridecell-operator/pkg/controller/djangouser/components"
 	"github.com/Ridecell/ridecell-operator/pkg/dbpool"
 	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
@@ -87,15 +87,15 @@ var _ = Describe("DjangoUser Database Component", func() {
 		dbpool.Dbs.Store("postgres host=foo-database port=5432 dbname=summon user=summon password='secretdbpass' sslmode=require", db)
 
 		// Baseline test instance.
-		instance.Spec = summonv1beta1.DjangoUserSpec{
+		instance.Spec = dbv1beta1.DjangoUserSpec{
 			Email:          "foo@example.com",
 			PasswordSecret: "foo-credentials",
-			Database: summonv1beta1.DatabaseConnection{
+			Database: dbv1beta1.PostgresConnection{
 				Host:     "foo-database",
 				Port:     5432,
 				Username: "summon",
 				Database: "summon",
-				PasswordSecretRef: summonv1beta1.SecretRef{
+				PasswordSecretRef: dbv1beta1.SecretRef{
 					Name: "summon.foo-database.credentials",
 					Key:  "password",
 				},
@@ -136,7 +136,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))
-		Expect(instance.Status.Status).To(Equal(summonv1beta1.StatusReady))
+		Expect(instance.Status.Status).To(Equal(dbv1beta1.StatusReady))
 		Expect(instance.Status.Message).To(Equal("User 1 created"))
 	})
 
@@ -164,7 +164,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))
-		Expect(instance.Status.Status).To(Equal(summonv1beta1.StatusReady))
+		Expect(instance.Status.Status).To(Equal(dbv1beta1.StatusReady))
 		Expect(instance.Status.Message).To(Equal("User 1 created"))
 	})
 
@@ -192,7 +192,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))
-		Expect(instance.Status.Status).To(Equal(summonv1beta1.StatusReady))
+		Expect(instance.Status.Status).To(Equal(dbv1beta1.StatusReady))
 		Expect(instance.Status.Message).To(Equal("User 1 created"))
 	})
 

--- a/pkg/controller/djangouser/components/defaults.go
+++ b/pkg/controller/djangouser/components/defaults.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
 )
 
@@ -40,7 +40,7 @@ func (_ *defaultsComponent) IsReconcilable(_ *components.ComponentContext) bool 
 }
 
 func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (components.Result, error) {
-	instance := ctx.Top.(*summonv1beta1.DjangoUser)
+	instance := ctx.Top.(*dbv1beta1.DjangoUser)
 
 	// Fill in defaults.
 	if instance.Spec.Email == "" {

--- a/pkg/controller/djangouser/components/secret.go
+++ b/pkg/controller/djangouser/components/secret.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
 )
 
@@ -49,7 +49,7 @@ func (_ *secretComponent) IsReconcilable(_ *components.ComponentContext) bool {
 }
 
 func (comp *secretComponent) Reconcile(ctx *components.ComponentContext) (components.Result, error) {
-	instance := ctx.Top.(*summonv1beta1.DjangoUser)
+	instance := ctx.Top.(*dbv1beta1.DjangoUser)
 
 	existing := &corev1.Secret{}
 	err := ctx.Get(ctx.Context, types.NamespacedName{Name: instance.Spec.PasswordSecret, Namespace: instance.Namespace}, existing)

--- a/pkg/controller/djangouser/controller.go
+++ b/pkg/controller/djangouser/controller.go
@@ -17,9 +17,9 @@ limitations under the License.
 package djangouser
 
 import (
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
 	djangousercomponents "github.com/Ridecell/ridecell-operator/pkg/controller/djangouser/components"
 )
@@ -27,7 +27,7 @@ import (
 // Add creates a new DjangoUser Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	_, err := components.NewReconciler("django-user-controller", mgr, &summonv1beta1.DjangoUser{}, nil, []components.Component{
+	_, err := components.NewReconciler("django-user-controller", mgr, &dbv1beta1.DjangoUser{}, nil, []components.Component{
 		djangousercomponents.NewDefaults(),
 		djangousercomponents.NewSecret(),
 		djangousercomponents.NewDatabase(),

--- a/pkg/controller/djangouser/controller_test.go
+++ b/pkg/controller/djangouser/controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/dbpool"
 	"github.com/Ridecell/ridecell-operator/pkg/test_helpers"
@@ -63,17 +64,17 @@ var _ = Describe("Summon controller", func() {
 	})
 
 	It("runs a basic reconcile", func() {
-		instance := &summonv1beta1.DjangoUser{
+		instance := &dbv1beta1.DjangoUser{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo.example.com", Namespace: helpers.Namespace},
-			Spec: summonv1beta1.DjangoUserSpec{
+			Spec: dbv1beta1.DjangoUserSpec{
 				Active:    true,
 				Staff:     true,
 				Superuser: true,
-				Database: summonv1beta1.DatabaseConnection{
+				Database: dbv1beta1.PostgresConnection{
 					Host:     "foo-database",
 					Username: "summon",
 					Database: "summon",
-					PasswordSecretRef: summonv1beta1.SecretRef{
+					PasswordSecretRef: dbv1beta1.SecretRef{
 						Name: "summon.foo-database.credentials",
 					},
 				},
@@ -97,7 +98,7 @@ var _ = Describe("Summon controller", func() {
 		err = helpers.Client.Create(context.TODO(), instance)
 		Expect(err).NotTo(HaveOccurred())
 
-		fetched := &summonv1beta1.DjangoUser{}
+		fetched := &dbv1beta1.DjangoUser{}
 		Eventually(func() (string, error) {
 			err := helpers.Client.Get(context.TODO(), types.NamespacedName{Name: "foo.example.com", Namespace: helpers.Namespace}, fetched)
 			if err != nil {

--- a/pkg/controller/summon/components/superuser.go
+++ b/pkg/controller/summon/components/superuser.go
@@ -25,6 +25,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
 )
@@ -37,7 +38,7 @@ func NewSuperuser() *superuserComponent {
 
 func (comp *superuserComponent) WatchTypes() []runtime.Object {
 	return []runtime.Object{
-		&summonv1beta1.DjangoUser{},
+		&dbv1beta1.DjangoUser{},
 	}
 }
 
@@ -72,8 +73,8 @@ func (comp *superuserComponent) Reconcile(ctx *components.ComponentContext) (com
 	}
 
 	res, _, err := ctx.CreateOrUpdate("superuser.yml.tpl", nil, func(goalObj, existingObj runtime.Object) error {
-		goal := goalObj.(*summonv1beta1.DjangoUser)
-		existing := existingObj.(*summonv1beta1.DjangoUser)
+		goal := goalObj.(*dbv1beta1.DjangoUser)
+		existing := existingObj.(*dbv1beta1.DjangoUser)
 		// Copy the Spec over.
 		existing.Spec = goal.Spec
 		return nil

--- a/pkg/controller/summon/components/superuser_test.go
+++ b/pkg/controller/summon/components/superuser_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 	summoncomponents "github.com/Ridecell/ridecell-operator/pkg/controller/summon/components"
 	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
 )
@@ -41,7 +41,7 @@ var _ = Describe("SummonPlatform Superuser Component", func() {
 		comp := summoncomponents.NewSuperuser()
 		Expect(comp).To(ReconcileContext(ctx))
 
-		user := &summonv1beta1.DjangoUser{}
+		user := &dbv1beta1.DjangoUser{}
 		err := ctx.Client.Get(context.Background(), types.NamespacedName{Name: "foo-dispatcher", Namespace: "default"}, user)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -53,14 +53,14 @@ var _ = Describe("SummonPlatform Superuser Component", func() {
 			comp := summoncomponents.NewSuperuser()
 			Expect(comp).To(ReconcileContext(ctx))
 
-			user := &summonv1beta1.DjangoUser{}
+			user := &dbv1beta1.DjangoUser{}
 			err := ctx.Client.Get(context.Background(), types.NamespacedName{Name: "foo-dispatcher", Namespace: "default"}, user)
 			Expect(err).To(HaveOccurred())
 			Expect(kerrors.IsNotFound(err)).To(BeTrue())
 		})
 
 		It("deletes an existing user", func() {
-			user := &summonv1beta1.DjangoUser{ObjectMeta: metav1.ObjectMeta{Name: "foo-dispatcher", Namespace: "default"}}
+			user := &dbv1beta1.DjangoUser{ObjectMeta: metav1.ObjectMeta{Name: "foo-dispatcher", Namespace: "default"}}
 			ctx.Client = fake.NewFakeClient(user)
 
 			comp := summoncomponents.NewSuperuser()

--- a/pkg/controller/summon/templates/superuser.yml.tpl
+++ b/pkg/controller/summon/templates/superuser.yml.tpl
@@ -1,4 +1,4 @@
-apiVersion: summon.ridecell.io/v1beta1
+apiVersion: db.ridecell.io/v1beta1
 kind: DjangoUser
 metadata:
   name: {{ .Instance.Name }}-dispatcher


### PR DESCRIPTION
It's more database related and we use Django for plenty of other services where this might be useful too.

Though we would need to deal with the Summon-specific tables if we did.

I could go either way on this one. It is actually summon-specific at the moment because the profile tables are (I think) only used in summon?