### PR TITLE
Make appsecrets react to changes in input secrets 

### DIFF
--- a/pkg/components/reconciler.go
+++ b/pkg/components/reconciler.go
@@ -67,7 +67,15 @@ func NewReconciler(name string, mgr manager.Manager, top runtime.Object, templat
 			if isAMapFuncWatch {
 				// Watch an arbitrary object via a MapFunc.
 				watchHandler = &handler.EnqueueRequestsFromMapFunc{
-					ToRequests: handler.ToRequestsFunc(mfComp.WatchMap),
+					ToRequests: handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
+						requests, err := mfComp.WatchMap(obj, cr.client)
+						if err != nil {
+							// For lack anything better to do for now ...
+							fmt.Printf("ERROR FROM MAP FUNC: %s", err)
+							panic(err)
+						}
+						return requests
+					}),
 				}
 			} else {
 				// Watch an owned object, but first check if we're already watching this type.

--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -75,7 +75,7 @@ type ErrorHandler interface {
 
 // An optional interface for Components which want to use EnqueueRequestsFromMapFunc instead of watching owned objects.
 type MapFuncWatcher interface {
-	WatchMap(handler.MapObject) []reconcile.Request
+	WatchMap(handler.MapObject, client.Client) ([]reconcile.Request, error)
 }
 
 // Opaque type for some kind of status substruct.

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -22,18 +22,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Ridecell/ridecell-operator/pkg/components"
-	"github.com/pkg/errors"
+	postgresv1 "github.com/zalando-incubator/postgres-operator/pkg/apis/acid.zalan.do/v1"
 	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
-	postgresv1 "github.com/zalando-incubator/postgres-operator/pkg/apis/acid.zalan.do/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/Ridecell/ridecell-operator/pkg/components"
+	"github.com/Ridecell/ridecell-operator/pkg/errors"
 )
 
 type appSecretComponent struct{}
@@ -100,11 +100,10 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	err := ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("%s.%s-database.credentials", strings.Replace(databaseUser, "_", "-", -1), databaseName), Namespace: instance.Namespace}, postgresSecret)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			// Don't trigger an error on notfound so it doesn't notify. Just try again.
-			return components.Result{Requeue: true}, nil
-		} else {
-			return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Postgres password not found")
+			// Not found here can be a normal thing during setup.
+			err = errors.NoNotify(err)
 		}
+		return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Postgres password not found")
 	}
 	postgresPassword, ok := postgresSecret.Data["password"]
 	if !ok {
@@ -115,11 +114,10 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	err = ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace}, fernetKeys)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			// Don't trigger an error on notfound so it doesn't notify. Just try again.
-			return components.Result{Requeue: true}, nil
-		} else {
-			return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Fernet keys secret not found")
+			// Not found here can be a normal thing during setup.
+			err = errors.NoNotify(err)
 		}
+		return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Fernet keys secret not found")
 	}
 	if len(fernetKeys.Data) == 0 {
 		return components.Result{}, errors.New("app_secrets: Fernet keys map is empty")
@@ -134,11 +132,10 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	err = ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace}, secretKey)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			// Don't trigger an error on notfound so it doesn't notify. Just try again.
-			return components.Result{Requeue: true}, nil
-		} else {
-			return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Unable to get SECRET_KEY")
+			// Not found here can be a normal thing during setup.
+			err = errors.NoNotify(err)
 		}
+		return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Unable to get SECRET_KEY")
 	}
 	val, ok := secretKey.Data["SECRET_KEY"]
 	if !ok || len(val) == 0 {
@@ -149,11 +146,10 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	err = ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("%s.aws-credentials", instance.Name), Namespace: instance.Namespace}, accessKey)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			// Don't trigger an error on notfound so it doesn't notify. Just try again.
-			return components.Result{Requeue: true}, nil
-		} else {
-			return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Unable to get aws credentials secret")
+			// Not found here can be a normal thing during setup.
+			err = errors.NoNotify(err)
 		}
+		return components.Result{Requeue: true}, errors.Wrapf(err, "app_secrets: Unable to get aws credentials secret")
 	}
 
 	appSecretsData := map[string]interface{}{}

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -162,7 +162,7 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	appSecretsData["CELERY_BROKER_URL"] = fmt.Sprintf("redis://%s-redis/2", instance.Name)
 	appSecretsData["FERNET_KEYS"] = formattedFernetKeys
 	appSecretsData["SECRET_KEY"] = string(secretKey.Data["SECRET_KEY"])
-	appSecretsData["AWS_ACCESS_KEY_ID"] = string(awsSecret.Data["AWS_SECRET_ACCESS_KEY"])
+	appSecretsData["AWS_ACCESS_KEY_ID"] = string(awsSecret.Data["AWS_ACCESS_KEY_ID"])
 	appSecretsData["AWS_SECRET_ACCESS_KEY"] = string(awsSecret.Data["AWS_SECRET_ACCESS_KEY"])
 
 	for _, secret := range specInputSecrets {

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -256,7 +256,11 @@ func (_ *appSecretComponent) fetchSecrets(ctx *components.ComponentContext, inst
 			if kerrors.IsNotFound(err) && allowMissing {
 				err = errors.NoNotify(err)
 			}
-			return nil, errors.Wrapf(err, "app_secrets: error fetching input app secret %s", secretName)
+			label := "input"
+			if allowMissing {
+				label = "derived"
+			}
+			return nil, errors.Wrapf(err, "app_secrets: error fetching %s app secret %s", label, secretName)
 		}
 		secrets = append(secrets, secret)
 	}

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -170,7 +170,7 @@ var _ = Describe("app_secrets Component", func() {
 	It("runs reconcile with no secret_key", func() {
 		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys)
 		res, err := comp.Reconcile(ctx)
-		Expect(err).To(MatchError(`app_secrets: error fetching input app secret foo.secret-key: secrets "foo.secret-key" not found`))
+		Expect(err).To(MatchError(`app_secrets: error fetching derived app secret foo.secret-key: secrets "foo.secret-key" not found`))
 		Expect(res.Requeue).To(BeTrue())
 	})
 

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -297,7 +297,7 @@ var _ = Describe("app_secrets Component", func() {
 
 		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys)
 		res, err := comp.Reconcile(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(MatchError(`app_secrets: Unable to get SECRET_KEY: secrets "foo.secret-key" not found`))
 		Expect(res.Requeue).To(BeTrue())
 	})
 

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -74,8 +74,8 @@ var _ = Describe("app_secrets Component", func() {
 		accessKey = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: "default"},
 			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
+				"AWS_ACCESS_KEY_ID":     []byte("testid"),
+				"AWS_SECRET_ACCESS_KEY": []byte("testkey"),
 			},
 		}
 
@@ -120,8 +120,8 @@ var _ = Describe("app_secrets Component", func() {
 		Expect(parsedYaml["SMS_WEBHOOK_URL"]).To(Equal("https://foo.ridecell.us/sms/receive/"))
 		Expect(parsedYaml["CELERY_BROKER_URL"]).To(Equal("redis://foo-redis/2"))
 		Expect(parsedYaml["TOKEN"]).To(Equal("secrettoken"))
-		Expect(parsedYaml["AWS_ACCESS_KEY_ID"]).To(Equal("test"))
-		Expect(parsedYaml["AWS_SECRET_ACCESS_KEY"]).To(Equal("test"))
+		Expect(parsedYaml["AWS_ACCESS_KEY_ID"]).To(Equal("testid"))
+		Expect(parsedYaml["AWS_SECRET_ACCESS_KEY"]).To(Equal("testkey"))
 	})
 
 	It("copies data from the input secret", func() {

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package components_test
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/Ridecell/ridecell-operator/pkg/components"
 	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,426 +34,207 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// This is just a subset of the secrets contained in the used object for testing.
-type testAppSecretData struct {
-	FERNET_KEYS           []string `yaml:"FERNET_KEYS,omitempty"`
-	DATABASE_URL          string   `yaml:"DATABASE_URL,omitempty"`
-	OUTBOUNDSMS_URL       string   `yaml:"OUTBOUNDSMS_URL,omitempty"`
-	SMS_WEBHOOK_URL       string   `yaml:"SMS_WEBHOOK_URL,omitempty"`
-	CELERY_BROKER_URL     string   `yaml:"CELERY_BROKER_URL,omitempty"`
-	ZIP_TAX_API_KEY       string   `yaml:"ZIP_TAX_API_KEY,omitempty"`
-	AWS_ACCESS_KEY_ID     string   `yaml:"AWS_ACCESS_KEY_ID,omitempty"`
-	AWS_SECRET_ACCESS_KEY string   `yaml:"AWS_SECRET_ACCESS_KEY,omitempty"`
-}
-
 var _ = Describe("app_secrets Component", func() {
+	var inSecret, postgresSecret, fernetKeys, secretKey, accessKey *corev1.Secret
+	var comp components.Component
 
 	BeforeEach(func() {
 		instance.Spec.Database.ExclusiveDatabase = true
+		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
+
+		inSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: "default"},
+			Data: map[string][]byte{
+				"TOKEN": []byte("secrettoken"),
+			},
+		}
+
+		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
+		fernetKeys = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo.fernet-keys", Namespace: "default"},
+			Data: map[string][]byte{
+				formattedTime: []byte("lorem ipsum"),
+			},
+		}
+
+		postgresSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "summon.foo-database.credentials", Namespace: "default"},
+			Data: map[string][]byte{
+				"password": []byte("postgresPassword"),
+			},
+		}
+
+		secretKey = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo.secret-key", Namespace: "default"},
+			Data: map[string][]byte{
+				"SECRET_KEY": []byte("testkey"),
+			},
+		}
+
+		accessKey = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: "default"},
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("test"),
+				"AWS_SECRET_ACCESS_KEY": []byte("test"),
+			},
+		}
+
+		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey)
+		comp = summoncomponents.NewAppSecret()
 	})
 
 	It("Unreconcilable when db not ready", func() {
-		comp := summoncomponents.NewAppSecret()
+		instance.Status.PostgresStatus = postgresv1.ClusterStatusUnknown
 		Expect(comp.IsReconcilable(ctx)).To(Equal(false))
 	})
 
 	It("Reconcilable when db is ready", func() {
-		comp := summoncomponents.NewAppSecret()
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
 		Expect(comp.IsReconcilable(ctx)).To(Equal(true))
 	})
 
 	It("Run reconcile without a postgres password", func() {
-		comp := summoncomponents.NewAppSecret()
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
+		ctx.Client = fake.NewFakeClient(inSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).ToNot(ReconcileContext(ctx))
 	})
 
 	It("Run reconcile with a blank postgres password", func() {
-		comp := summoncomponents.NewAppSecret()
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret)
+		delete(postgresSecret.Data, "password")
+		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey)
 		_, err := comp.Reconcile(ctx)
-		Expect(err.Error()).To(Equal("app_secrets: Postgres password not found in secret"))
+		Expect(err).To(MatchError("app_secrets: Postgres password not found in secret"))
 	})
 
 	It("Sets postgres password and checks reconcile output", func() {
-		comp := summoncomponents.NewAppSecret()
-		//Set status so that IsReconcileable returns true
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"filler": []byte("test")},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("lorem ipsum")},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
-			},
-		}
-
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
-			},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 
 		fetchSecret := &corev1.Secret{}
-		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace}, fetchSecret)
+		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: "foo.app-secrets", Namespace: "default"}, fetchSecret)
 		Expect(err).ToNot(HaveOccurred())
 
-		byteData := fetchSecret.Data["summon-platform.yml"]
-		var parsedYaml testAppSecretData
-		err = yaml.Unmarshal(byteData, &parsedYaml)
+		var parsedYaml map[string]interface{}
+		err = yaml.Unmarshal(fetchSecret.Data["summon-platform.yml"], &parsedYaml)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(parsedYaml.DATABASE_URL)).To(Equal("postgis://summon:postgresPassword@foo-database/summon"))
-		Expect(string(parsedYaml.OUTBOUNDSMS_URL)).To(Equal("https://foo.prod.ridecell.io/outbound-sms"))
-		Expect(string(parsedYaml.SMS_WEBHOOK_URL)).To(Equal("https://foo.ridecell.us/sms/receive/"))
-		Expect(string(parsedYaml.CELERY_BROKER_URL)).To(Equal("redis://foo-redis/2"))
-		Expect(string(parsedYaml.ZIP_TAX_API_KEY)).To(Equal(""))
-		Expect(string(parsedYaml.AWS_ACCESS_KEY_ID)).To(Equal("test"))
-		Expect(string(parsedYaml.AWS_SECRET_ACCESS_KEY)).To(Equal("test"))
+		Expect(parsedYaml["DATABASE_URL"]).To(Equal("postgis://summon:postgresPassword@foo-database/summon"))
+		Expect(parsedYaml["OUTBOUNDSMS_URL"]).To(Equal("https://foo.prod.ridecell.io/outbound-sms"))
+		Expect(parsedYaml["SMS_WEBHOOK_URL"]).To(Equal("https://foo.ridecell.us/sms/receive/"))
+		Expect(parsedYaml["CELERY_BROKER_URL"]).To(Equal("redis://foo-redis/2"))
+		Expect(parsedYaml["TOKEN"]).To(Equal("secrettoken"))
+		Expect(parsedYaml["AWS_ACCESS_KEY_ID"]).To(Equal("test"))
+		Expect(parsedYaml["AWS_SECRET_ACCESS_KEY"]).To(Equal("test"))
 	})
 
 	It("copies data from the input secret", func() {
-		comp := summoncomponents.NewAppSecret()
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"ZIP_TAX_API_KEY": []byte("taxessss")},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("lorem ipsum")},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
-			},
-		}
-
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
-			},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 
 		fetchSecret := &corev1.Secret{}
-		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace}, fetchSecret)
+		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: "foo.app-secrets", Namespace: "default"}, fetchSecret)
 		Expect(err).ToNot(HaveOccurred())
 
-		byteData := fetchSecret.Data["summon-platform.yml"]
-		var parsedYaml testAppSecretData
-		err = yaml.Unmarshal(byteData, &parsedYaml)
+		var parsedYaml map[string]interface{}
+		err = yaml.Unmarshal(fetchSecret.Data["summon-platform.yml"], &parsedYaml)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(parsedYaml.ZIP_TAX_API_KEY)).To(Equal("taxessss"))
+		Expect(parsedYaml["TOKEN"]).To(Equal("secrettoken"))
 	})
 
 	It("reconciles with existing fernet keys", func() {
-		comp := summoncomponents.NewAppSecret()
-
-		// Is there a way I could write this setup in not such a verbose way?
 		now := time.Now().UTC()
-		unsortedTimes := make(map[string][]byte)
-
-		durationOne, _ := time.ParseDuration("-1h")
-		durationTwo, _ := time.ParseDuration("-2h")
-		durationThree, _ := time.ParseDuration("-3h")
-		durationFour, _ := time.ParseDuration("-4h")
-		durationFive, _ := time.ParseDuration("-5h")
-
-		timeOne := now.Add(durationOne)
-		timeTwo := now.Add(durationTwo)
-		timeThree := now.Add(durationThree)
-		timeFour := now.Add(durationFour)
-		timeFive := now.Add(durationFive)
-
-		unsortedTimes[time.Time.Format(timeOne, summoncomponents.CustomTimeLayout)] = []byte("1")
-		unsortedTimes[time.Time.Format(timeTwo, summoncomponents.CustomTimeLayout)] = []byte("2")
-		unsortedTimes[time.Time.Format(timeThree, summoncomponents.CustomTimeLayout)] = []byte("3")
-		unsortedTimes[time.Time.Format(timeFour, summoncomponents.CustomTimeLayout)] = []byte("4")
-		unsortedTimes[time.Time.Format(timeFive, summoncomponents.CustomTimeLayout)] = []byte("5")
-
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       unsortedTimes,
+		addKey := func(k, v string) {
+			d, _ := time.ParseDuration(k)
+			fernetKeys.Data[time.Time.Format(now.Add(d), summoncomponents.CustomTimeLayout)] = []byte(v)
 		}
+		fernetKeys.Data = map[string][]byte{}
+		addKey("-1h", "1")
+		addKey("-2h", "2")
+		addKey("-3h", "3")
+		addKey("-4h", "4")
+		addKey("-5h", "5")
+		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey)
 
-		//Set status so that IsReconcileable returns true
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
-			},
-		}
-
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
-			},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 
 		fetchSecret := &corev1.Secret{}
-		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace}, fetchSecret)
+		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: "foo.app-secrets", Namespace: "default"}, fetchSecret)
 		Expect(err).ToNot(HaveOccurred())
 
-		byteData := fetchSecret.Data["summon-platform.yml"]
-		var parsedYaml testAppSecretData
-		err = yaml.Unmarshal(byteData, &parsedYaml)
+		var parsedYaml struct {
+			Keys []string `yaml:"FERNET_KEYS"`
+		}
+		err = yaml.Unmarshal(fetchSecret.Data["summon-platform.yml"], &parsedYaml)
 		Expect(err).ToNot(HaveOccurred())
 
-		stringSlices := parsedYaml.FERNET_KEYS
-
-		expectedSlices := []string{"1", "2", "3", "4", "5"}
-		Expect(stringSlices).To(Equal(expectedSlices))
-
+		Expect(parsedYaml.Keys).To(Equal([]string{"1", "2", "3", "4", "5"}))
 	})
 
 	It("runs reconcile with no secret_key", func() {
-		comp := summoncomponents.NewAppSecret()
-		//Set status so that IsReconcileable returns true
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"filler": []byte("test")},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("lorem ipsum")},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys)
+		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys)
 		res, err := comp.Reconcile(ctx)
-		Expect(err).To(MatchError(`app_secrets: Unable to get SECRET_KEY: secrets "foo.secret-key" not found`))
+		Expect(err).To(MatchError(`app_secrets: error fetching input app secret foo.secret-key: secrets "foo.secret-key" not found`))
 		Expect(res.Requeue).To(BeTrue())
 	})
 
 	It("runs reconcile with all values set", func() {
-		comp := summoncomponents.NewAppSecret()
-
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("filler value")},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s-database.credentials", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
-			},
-		}
-
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
-			},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 	})
 
 	It("overwrites values using multiple secrets", func() {
-		instance.Spec.Secrets = []string{"testsecret0", "testsecret1", "testsecret2"}
-		comp := summoncomponents.NewAppSecret()
+		instance.Spec.Secrets = []string{"testsecret", "testsecret2", "testsecret3"}
 
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret0", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"test0": []byte("filler")},
-		}
-
-		newAppSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret1", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"test0": []byte("overwritten")},
-		}
-
-		thirdAppSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret2", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"test0": []byte("overwritten_again")},
-		}
-
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.fernet-keys", Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("filler value")},
-		}
-
-		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "summon.foo-database.credentials", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"password": []byte("postgresPassword")},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.secret-key", Namespace: instance.Namespace},
+		inSecret2 := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret2", Namespace: "default"},
 			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
+				"TOKEN": []byte("overwritten"),
 			},
 		}
 
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
+		inSecret3 := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret3", Namespace: "default"},
 			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
+				"TOKEN": []byte("overwritten_again"),
 			},
 		}
 
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, newAppSecrets, thirdAppSecrets, accessKey)
+		ctx.Client = fake.NewFakeClient(inSecret, inSecret2, inSecret3, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 
 		fetchSecret := &corev1.Secret{}
-		err := ctx.Get(ctx.Context, types.NamespacedName{Name: "summon.foo.app-secrets", Namespace: instance.Namespace}, fetchSecret)
+		err := ctx.Get(ctx.Context, types.NamespacedName{Name: "foo.app-secrets", Namespace: "default"}, fetchSecret)
 		Expect(err).ToNot(HaveOccurred())
 
 		appSecretsData := map[string]interface{}{}
 
 		err = yaml.Unmarshal(fetchSecret.Data["summon-platform.yml"], &appSecretsData)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(appSecretsData["test0"].(string)).To(Equal("overwritten_again"))
+		Expect(appSecretsData["TOKEN"]).To(Equal("overwritten_again"))
 
 	})
 
 	It("reconciles with shared database config", func() {
-		comp := summoncomponents.NewAppSecret()
-		//Set status so that IsReconcileable returns true
-		instance.Status.PostgresStatus = postgresv1.ClusterStatusRunning
 		instance.Spec.Database.ExclusiveDatabase = false
 		instance.Spec.Database.SharedDatabaseName = "shareddb"
 
-		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: instance.Namespace},
-			Data:       map[string][]byte{"filler": []byte("test")},
-		}
-
 		postgresSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.shareddb-database.credentials", Namespace: instance.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: "foo.shareddb-database.credentials", Namespace: "default"},
 			Data:       map[string][]byte{"password": []byte("postgresPassword")},
 		}
+		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey)
 
-		formattedTime := time.Time.Format(time.Now().UTC(), summoncomponents.CustomTimeLayout)
-
-		fernetKeys := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.fernet-keys", instance.Name), Namespace: instance.Namespace},
-			Data:       map[string][]byte{formattedTime: []byte("lorem ipsum")},
-		}
-
-		secretKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.secret-key", instance.Name), Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"SECRET_KEY": []byte("testkey"),
-			},
-		}
-
-		accessKey := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo.aws-credentials", Namespace: instance.Namespace},
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("test"),
-				"AWS_SECRET_ACCESS_KEY": []byte("test"),
-			},
-		}
-
-		ctx.Client = fake.NewFakeClient(appSecrets, postgresSecret, fernetKeys, secretKey, accessKey)
 		Expect(comp).To(ReconcileContext(ctx))
 
 		fetchSecret := &corev1.Secret{}
-		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace}, fetchSecret)
+		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: "foo.app-secrets", Namespace: "default"}, fetchSecret)
 		Expect(err).ToNot(HaveOccurred())
 
 		byteData := fetchSecret.Data["summon-platform.yml"]
-		var parsedYaml testAppSecretData
+		var parsedYaml map[string]interface{}
 		err = yaml.Unmarshal(byteData, &parsedYaml)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(parsedYaml.DATABASE_URL)).To(Equal("postgis://foo:postgresPassword@shareddb-database/foo"))
-		Expect(string(parsedYaml.OUTBOUNDSMS_URL)).To(Equal("https://foo.prod.ridecell.io/outbound-sms"))
-		Expect(string(parsedYaml.SMS_WEBHOOK_URL)).To(Equal("https://foo.ridecell.us/sms/receive/"))
-		Expect(string(parsedYaml.CELERY_BROKER_URL)).To(Equal("redis://foo-redis/2"))
-		Expect(string(parsedYaml.ZIP_TAX_API_KEY)).To(Equal(""))
+		Expect(parsedYaml["DATABASE_URL"]).To(Equal("postgis://foo:postgresPassword@shareddb-database/foo"))
+		Expect(parsedYaml["OUTBOUNDSMS_URL"]).To(Equal("https://foo.prod.ridecell.io/outbound-sms"))
+		Expect(parsedYaml["SMS_WEBHOOK_URL"]).To(Equal("https://foo.ridecell.us/sms/receive/"))
+		Expect(parsedYaml["CELERY_BROKER_URL"]).To(Equal("redis://foo-redis/2"))
+		Expect(parsedYaml["TOKEN"]).To(Equal("secrettoken"))
 	})
 })

--- a/pkg/controller/summon/components/deployment.go
+++ b/pkg/controller/summon/components/deployment.go
@@ -71,7 +71,7 @@ func (comp *deploymentComponent) Reconcile(ctx *components.ComponentContext) (co
 	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
 
 	rawAppSecret := &corev1.Secret{}
-	err := ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace}, rawAppSecret)
+	err := ctx.Get(ctx.Context, types.NamespacedName{Name: fmt.Sprintf("%s.app-secrets", instance.Name), Namespace: instance.Namespace}, rawAppSecret)
 	if err != nil {
 		return components.Result{Requeue: true}, errors.Wrapf(err, "deployment: Failed to get appsecrets")
 	}

--- a/pkg/controller/summon/components/deployment_test.go
+++ b/pkg/controller/summon/components/deployment_test.go
@@ -48,7 +48,7 @@ var _ = Describe("deployment Component", func() {
 		}
 
 		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.app-secrets", instance.Name), Namespace: instance.Namespace},
 			Data: map[string][]byte{
 				"filler": []byte("test"),
 				"test":   []byte("another_test"),
@@ -81,7 +81,7 @@ var _ = Describe("deployment Component", func() {
 		}
 
 		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.app-secrets", instance.Name), Namespace: instance.Namespace},
 			Data: map[string][]byte{
 				"test":   []byte("another_test"),
 				"filler": []byte("test"),
@@ -113,7 +113,7 @@ var _ = Describe("deployment Component", func() {
 		}
 
 		appSecrets := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.app-secrets", instance.Name), Namespace: instance.Namespace},
 			Data:       map[string][]byte{"filler": []byte("test")},
 		}
 
@@ -127,7 +127,7 @@ var _ = Describe("deployment Component", func() {
 		}
 
 		appSecrets = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("summon.%s.app-secrets", instance.Name), Namespace: instance.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.app-secrets", instance.Name), Namespace: instance.Namespace},
 			Data:       map[string][]byte{"filler": []byte("test2")},
 		}
 

--- a/pkg/controller/summon/components/notification.go
+++ b/pkg/controller/summon/components/notification.go
@@ -27,6 +27,7 @@ import (
 
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
+	"github.com/Ridecell/ridecell-operator/pkg/errors"
 )
 
 var versionRegex *regexp.Regexp
@@ -96,6 +97,9 @@ func (c *notificationComponent) Reconcile(ctx *components.ComponentContext) (com
 
 // ReconcileError implements components.ErrorHandler.
 func (c *notificationComponent) ReconcileError(ctx *components.ComponentContext, err error) (components.Result, error) {
+	if !errors.ShouldNotify(err) {
+		return components.Result{}, nil
+	}
 	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
 	return c.handleError(instance, fmt.Sprintf("%s", err))
 }

--- a/pkg/controller/summon/controller_appsecrets_test.go
+++ b/pkg/controller/summon/controller_appsecrets_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2019 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package summon_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	postgresv1 "github.com/zalando-incubator/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	"github.com/Ridecell/ridecell-operator/pkg/test_helpers"
+)
+
+var _ = Describe("Summon controller appsecrets", func() {
+	var helpers *test_helpers.PerTestHelpers
+	var instance *summonv1beta1.SummonPlatform
+
+	BeforeEach(func() {
+		helpers = testHelpers.SetupTest()
+
+		// Set up the instance object for other tests.
+		instance = &summonv1beta1.SummonPlatform{
+			ObjectMeta: metav1.ObjectMeta{Name: "appsecretstest", Namespace: helpers.Namespace},
+			Spec: summonv1beta1.SummonPlatformSpec{
+				Version: "80813-eb6b515-master",
+				Secrets: []string{},
+				Database: summonv1beta1.DatabaseSpec{
+					ExclusiveDatabase: true,
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		// Display some debugging info if the test failed.
+		if CurrentGinkgoTestDescription().Failed {
+			summons := &summonv1beta1.SummonPlatformList{}
+			err := helpers.Client.List(context.Background(), nil, summons)
+			if err != nil {
+				fmt.Printf("!!!!!! %s\n", err)
+			} else {
+				fmt.Print("Failed instances:\n")
+				for _, item := range summons.Items {
+					if item.Namespace == helpers.Namespace {
+						fmt.Printf("\t%s %#v\n", item.Name, item.Status)
+					}
+				}
+			}
+		}
+
+		helpers.TeardownTest()
+	})
+
+	It("creates the app secret if all inputs exist already", func() {
+		c := helpers.TestClient
+
+		// Create all the input secrets.
+		inputSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: helpers.Namespace},
+			Data: map[string][]byte{
+				"filler": []byte{}}}
+		c.Create(inputSecret)
+		awsSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "appsecretstest.aws-credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIAtest",
+				"AWS_SECRET_ACCESS_KEY": "test",
+			},
+		}
+		c.Create(awsSecret)
+		dbSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "summon.appsecretstest-database.credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"password": "secretdbpass",
+			},
+		}
+		c.Create(dbSecret)
+
+		// Create the instance.
+		instance.Spec.Secrets = []string{"testsecret"}
+		c.Create(instance)
+
+		// Advance postgres to running.
+		postgres := &postgresv1.Postgresql{}
+		c.EventuallyGet(helpers.Name("appsecretstest-database"), postgres)
+		postgres.Status = postgresv1.ClusterStatusRunning
+		c.Status().Update(postgres)
+
+		// Get the output app secrets.
+		appSecret := &corev1.Secret{}
+		c.EventuallyGet(helpers.Name("appsecretstest.app-secrets"), appSecret)
+
+		// Parse the YAML to check it.
+		data := map[string]interface{}{}
+		err := yaml.Unmarshal(appSecret.Data["summon-platform.yml"], &data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data["DATABASE_URL"]).To(Equal("postgis://summon:secretdbpass@appsecretstest-database/summon"))
+	})
+
+	It("creates the app secret the database secret is created afterwards", func() {
+		c := helpers.TestClient
+
+		// Create some of the input secrets.
+		inputSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: helpers.Namespace},
+			Data: map[string][]byte{
+				"filler": []byte{}}}
+		c.Create(inputSecret)
+		awsSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "appsecretstest.aws-credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIAtest",
+				"AWS_SECRET_ACCESS_KEY": "test",
+			},
+		}
+		c.Create(awsSecret)
+
+		// Create the instance.
+		instance.Spec.Secrets = []string{"testsecret"}
+		c.Create(instance)
+
+		// Advance postgres to running.
+		postgres := &postgresv1.Postgresql{}
+		c.EventuallyGet(helpers.Name("appsecretstest-database"), postgres)
+		postgres.Status = postgresv1.ClusterStatusRunning
+		c.Status().Update(postgres)
+
+		// Create the DB secret later than where it would normally be created.
+		time.Sleep(2 * time.Second)
+		dbSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "summon.appsecretstest-database.credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"password": "secretdbpass",
+			},
+		}
+		c.Create(dbSecret)
+
+		// Get the output app secrets.
+		appSecret := &corev1.Secret{}
+		c.EventuallyGet(helpers.Name("appsecretstest.app-secrets"), appSecret)
+
+		// Parse the YAML to check it.
+		data := map[string]interface{}{}
+		err := yaml.Unmarshal(appSecret.Data["summon-platform.yml"], &data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data["DATABASE_URL"]).To(Equal("postgis://summon:secretdbpass@appsecretstest-database/summon"))
+	})
+
+	It("creates the app secret the database secret is changed afterwards", func() {
+		c := helpers.TestClient
+
+		// Create some of the input secrets.
+		inputSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "testsecret", Namespace: helpers.Namespace},
+			Data: map[string][]byte{
+				"filler": []byte{}}}
+		c.Create(inputSecret)
+		dbSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "summon.appsecretstest-database.credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"password": "secretdbpass",
+			},
+		}
+		c.Create(dbSecret)
+		awsSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "appsecretstest.aws-credentials", Namespace: helpers.Namespace},
+			StringData: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIAtest",
+				"AWS_SECRET_ACCESS_KEY": "test",
+			},
+		}
+		c.Create(awsSecret)
+
+		// Create the instance.
+		instance.Spec.Secrets = []string{"testsecret"}
+		c.Create(instance)
+
+		// Advance postgres to running.
+		postgres := &postgresv1.Postgresql{}
+		c.EventuallyGet(helpers.Name("appsecretstest-database"), postgres)
+		postgres.Status = postgresv1.ClusterStatusRunning
+		c.Status().Update(postgres)
+
+		// Change the DB secret
+		time.Sleep(10 * time.Second)
+		dbSecret.StringData["password"] = "other"
+		c.Update(dbSecret)
+
+		// Get the output app secrets.
+		appSecret := &corev1.Secret{}
+		data := map[string]interface{}{}
+		c.EventuallyGet(helpers.Name("appsecretstest.app-secrets"), appSecret, c.EventuallyValue("postgis://summon:other@appsecretstest-database/summon", func(obj runtime.Object) (interface{}, error) {
+			err := yaml.Unmarshal(appSecret.Data["summon-platform.yml"], &data)
+			if err != nil {
+				return nil, err
+			}
+			return data["DATABASE_URL"], nil
+		}))
+	})
+})

--- a/pkg/controller/summon/controller_notification_test.go
+++ b/pkg/controller/summon/controller_notification_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Summon controller", func() {
 		c.EventuallyGet(helpers.Name("notifytest"), fetchInstance, c.EventuallyStatus(summonv1beta1.StatusReady))
 
 		// Check that the notification state saved correctly. This is mostly to wait until the final reconcile before exiting the test.
-		c.EventuallyGet(helpers.Name("notifytest"), fetchInstance, c.EventuallyValue("80813-eb6b515-master", func(obj runtime.Object) (interface{}, error) {
+		c.EventuallyGet(helpers.Name("notifytest"), fetchInstance, c.EventuallyValue(Equal("80813-eb6b515-master"), func(obj runtime.Object) (interface{}, error) {
 			return obj.(*summonv1beta1.SummonPlatform).Status.Notification.NotifyVersion, nil
 		}))
 

--- a/pkg/controller/summon/templates/celerybeat/statefulset.yml.tpl
+++ b/pkg/controller/summon/templates/celerybeat/statefulset.yml.tpl
@@ -67,7 +67,7 @@ spec:
             name: {{ .Instance.Name }}-config
         - name: app-secrets
           secret:
-            secretName: summon.{{ .Instance.Name }}.app-secrets
+            secretName: {{ .Instance.Name }}.app-secrets
   volumeClaimTemplates:
   - metadata:
       name: beat-state

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -56,5 +56,5 @@ spec:
             name: {{ .Instance.Name }}-config
         - name: app-secrets
           secret:
-            secretName: summon.{{ .Instance.Name }}.app-secrets
+            secretName: {{ .Instance.Name }}.app-secrets
 {{ end }}

--- a/pkg/controller/summon/templates/migrations.yml.tpl
+++ b/pkg/controller/summon/templates/migrations.yml.tpl
@@ -51,4 +51,4 @@ spec:
             name: {{ .Instance.Name }}-config
         - name: app-secrets
           secret:
-            secretName: summon.{{ .Instance.Name }}.app-secrets
+            secretName: {{ .Instance.Name }}.app-secrets

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Re-export all the important methods from pkg/errors.
+var New = errors.New
+var Errorf = errors.Errorf
+var Wrap = errors.Wrap
+var Wrapf = errors.Wrapf
+var Cause = errors.Cause
+
+// Because errors doesn't expose this.
+type causer interface {
+	Cause() error
+}
+
+// An error that should not get a notification.
+func NoNotify(err error) error {
+	return &noNotify{error: err}
+}
+
+type noNotify struct{ error }
+
+func (n *noNotify) Cause() error {
+	c, ok := n.error.(causer)
+	if ok {
+		return c.Cause()
+	} else {
+		return n.error
+	}
+}
+
+func ShouldNotify(err error) bool {
+	for err != nil {
+		_, ok := err.(*noNotify)
+		if ok {
+			return false
+		}
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return true
+}

--- a/pkg/errors/errors_suite_test.go
+++ b/pkg/errors/errors_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Errors Suite")
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Ridecell/ridecell-operator/pkg/errors"
+)
+
+var _ = Describe("Errors", func() {
+	Describe("Re-exported methods", func() {
+		It("exposes errors.New", func() {
+			err := errors.New("test error")
+			Expect(err).To(MatchError("test error"))
+		})
+
+		It("exposes errors.Errorf", func() {
+			err := errors.Errorf("test %s", "error")
+			Expect(err).To(MatchError("test error"))
+		})
+
+		It("exposes errors.Wrap", func() {
+			err := errors.New("test error")
+			err2 := errors.Wrap(err, "outer error")
+			Expect(err2).To(MatchError("outer error: test error"))
+		})
+
+		It("exposes errors.Wrapf", func() {
+			err := errors.New("test error")
+			err2 := errors.Wrapf(err, "outer %s", "error")
+			Expect(err2).To(MatchError("outer error: test error"))
+		})
+
+		It("exposes errors.Cause", func() {
+			err := errors.New("test error")
+			err2 := errors.Wrap(err, "outer error")
+			Expect(errors.Cause(err2)).To(Equal(err))
+		})
+	})
+
+	Describe("ShouldNotify", func() {
+		It("returns true for a fmt.Errorf", func() {
+			err := fmt.Errorf("test error")
+			Expect(errors.ShouldNotify(err)).To(BeTrue())
+		})
+
+		It("returns true for an errors.New", func() {
+			err := errors.Errorf("test error")
+			Expect(errors.ShouldNotify(err)).To(BeTrue())
+		})
+
+		It("returns true for a errors.Errorf", func() {
+			err := errors.Errorf("test error")
+			Expect(errors.ShouldNotify(err)).To(BeTrue())
+		})
+
+		It("returns false for a top-level NoNotify", func() {
+			err := errors.Errorf("test error")
+			err2 := errors.NoNotify(err)
+			Expect(errors.ShouldNotify(err2)).To(BeFalse())
+			Expect(err2).To(MatchError("test error"))
+			Expect(errors.Cause(err2)).To(Equal(err))
+		})
+
+		It("returns false for an intermediary NoNotify", func() {
+			err := errors.Errorf("test error")
+			err2 := errors.Wrap(errors.NoNotify(err), "outer error")
+			Expect(errors.ShouldNotify(err2)).To(BeFalse())
+			Expect(err2).To(MatchError("outer error: test error"))
+			Expect(errors.Cause(err2)).To(Equal(err))
+		})
+	})
+})


### PR DESCRIPTION
This fixes the problem that when secrets are updated, no reconcile is triggered so the compiled output app secrets are not updated to match.