### PR TITLE
RDS Controller changes

### DIFF
--- a/pkg/apis/db/v1beta1/rds_types.go
+++ b/pkg/apis/db/v1beta1/rds_types.go
@@ -24,7 +24,7 @@ import (
 type RDSInstanceSpec struct {
 	AllocatedStorage int64  `json:"allocatedStorage,omitempty"`
 	DatabaseName     string `json:"databaseName,omitempty"`
-	InstanceID       string `json:instanceID,omitempty`
+	InstanceID       string `json:"instanceID,omitempty"`
 	Engine           string `json:"engine,omitempty"`
 	EngineVersion    string `json:"engineVersion,omitempty"`
 	InstanceClass    string `json:"instanceClass,omitempty"`

--- a/pkg/apis/db/v1beta1/rds_types.go
+++ b/pkg/apis/db/v1beta1/rds_types.go
@@ -24,6 +24,7 @@ import (
 type RDSInstanceSpec struct {
 	AllocatedStorage int64  `json:"allocatedStorage,omitempty"`
 	DatabaseName     string `json:"databaseName,omitempty"`
+	InstanceID       string `json:instanceID,omitempty`
 	Engine           string `json:"engine,omitempty"`
 	EngineVersion    string `json:"engineVersion,omitempty"`
 	InstanceClass    string `json:"instanceClass,omitempty"`

--- a/pkg/controller/rds/components/defaults.go
+++ b/pkg/controller/rds/components/defaults.go
@@ -71,10 +71,6 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		instance.Spec.SubnetGroupName = os.Getenv("AWS_SUBNET_GROUP_NAME")
 	}
 
-	if instance.Spec.VPCID == "" {
-		instance.Spec.VPCID = os.Getenv("VPC_ID")
-	}
-
 	if instance.Spec.DatabaseName == "" {
 		instance.Spec.DatabaseName = instance.Name
 	}

--- a/pkg/controller/rds/components/defaults.go
+++ b/pkg/controller/rds/components/defaults.go
@@ -46,6 +46,10 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		instance.Spec.AllocatedStorage = 100
 	}
 
+	if instance.Spec.InstanceID == "" {
+		instance.Spec.InstanceID = instance.Name
+	}
+
 	if instance.Spec.Engine == "" {
 		instance.Spec.Engine = "postgres"
 	}

--- a/pkg/controller/rds/components/defaults_test.go
+++ b/pkg/controller/rds/components/defaults_test.go
@@ -28,12 +28,14 @@ var _ = Describe("rds Defaults Component", func() {
 	It("does nothing on a filled out object", func() {
 		comp := rdscomponents.NewDefaults()
 		instance.Spec.AllocatedStorage = 200
+		instance.Spec.InstanceID = "nochange"
 		instance.Spec.Engine = "test"
 		instance.Spec.EngineVersion = "2"
 		instance.Spec.InstanceClass = "db.m5.4xlarge"
 
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.Spec.AllocatedStorage).To(Equal(int64(200)))
+		Expect(instance.Spec.InstanceID).To(Equal("nochange"))
 		Expect(instance.Spec.Engine).To(Equal("test"))
 		Expect(instance.Spec.EngineVersion).To(Equal("2"))
 		Expect(instance.Spec.InstanceClass).To(Equal("db.m5.4xlarge"))
@@ -44,6 +46,7 @@ var _ = Describe("rds Defaults Component", func() {
 		Expect(comp).To(ReconcileContext(ctx))
 
 		Expect(instance.Spec.AllocatedStorage).To(Equal(int64(100)))
+		Expect(instance.Spec.InstanceID).To(Equal("test"))
 		Expect(instance.Spec.Engine).To(Equal("postgres"))
 		Expect(instance.Spec.EngineVersion).To(Equal("11"))
 		Expect(instance.Spec.InstanceClass).To(Equal("db.t3.micro"))

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -151,6 +151,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 			DBParameterGroupName:       aws.String(instance.Name),
 			VpcSecurityGroupIds:        []*string{aws.String(instance.Status.SecurityGroupID)},
 			DBSubnetGroupName:          aws.String(instance.Spec.SubnetGroupName),
+			StorageEncrypted:           aws.Bool(true),
 			Tags: []*rds.Tag{
 				&rds.Tag{
 					Key:   aws.String("Ridecell-Operator"),

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -76,7 +76,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	} else {
 		if helpers.ContainsFinalizer(RDSInstanceDatabaseFinalizer, instance) {
 			describeDBInstancesOutput, err := comp.rdsAPI.DescribeDBInstances(&rds.DescribeDBInstancesInput{
-				DBInstanceIdentifier: aws.String(instance.Name),
+				DBInstanceIdentifier: aws.String(instance.Spec.InstanceID),
 			})
 			if err != nil {
 				if aerr, ok := err.(awserr.Error); ok && aerr.Code() != rds.ErrCodeDBInstanceNotFoundFault {
@@ -125,7 +125,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	}
 
 	describeDBInstancesOutput, err := comp.rdsAPI.DescribeDBInstances(&rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(instance.Name),
+		DBInstanceIdentifier: aws.String(instance.Spec.InstanceID),
 	})
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() != rds.ErrCodeDBInstanceNotFoundFault {
@@ -137,7 +137,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	if databaseNotExist {
 		createDBInstanceOutput, err := comp.rdsAPI.CreateDBInstance(&rds.CreateDBInstanceInput{
 			MasterUsername:             aws.String(databaseUsername),
-			DBInstanceIdentifier:       aws.String(instance.Name),
+			DBInstanceIdentifier:       aws.String(instance.Spec.InstanceID),
 			DBName:                     aws.String(databaseName),
 			MasterUserPassword:         aws.String(string(password)),
 			StorageType:                aws.String("gp2"),
@@ -209,7 +209,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	// For now we're only making changes that are safe to apply immediately
 	// This does exclude instance size for now
 	databaseModifyInput := &rds.ModifyDBInstanceInput{
-		DBInstanceIdentifier: aws.String(instance.Name),
+		DBInstanceIdentifier: database.DBInstanceIdentifier,
 		ApplyImmediately:     aws.Bool(true),
 	}
 	// TODO: Things could get weird if allocated storage is increased by less than 10% as aws will automatically round up to the nearest 10% increase
@@ -309,8 +309,8 @@ func (comp *rdsInstanceComponent) deleteDependencies(ctx *components.ComponentCo
 	instance := ctx.Top.(*dbv1beta1.RDSInstance)
 
 	_, err := comp.rdsAPI.DeleteDBInstance(&rds.DeleteDBInstanceInput{
-		DBInstanceIdentifier:      aws.String(instance.Name),
-		FinalDBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", instance.Name, time.Now().UTC().Format("2006-01-02-15-04"))),
+		DBInstanceIdentifier:      aws.String(instance.Spec.InstanceID),
+		FinalDBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", instance.Spec.InstanceID, time.Now().UTC().Format("2006-01-02-15-04"))),
 	})
 
 	if err != nil {

--- a/pkg/controller/rds/components/rds_instance_test.go
+++ b/pkg/controller/rds/components/rds_instance_test.go
@@ -67,6 +67,7 @@ var _ = Describe("rds aws Component", func() {
 		comp = rdscomponents.NewRDSInstance()
 		mockRDS = &mockRDSDBClient{}
 		comp.InjectRDSAPI(mockRDS)
+		instance.Spec.InstanceID = "test"
 		instance.Spec.SubnetGroupName = "test"
 		instance.Status.Connection = dbv1beta1.PostgresConnection{
 			Host:     "test-database",

--- a/pkg/controller/rds/controller_test.go
+++ b/pkg/controller/rds/controller_test.go
@@ -46,6 +46,7 @@ var rdssvc *rds.RDS
 var ec2svc *ec2.EC2
 var rdsInstance *dbv1beta1.RDSInstance
 var randOwnerPrefix string
+var rdsInstanceName string
 
 var _ = Describe("rds controller", func() {
 	var helpers *test_helpers.PerTestHelpers
@@ -66,6 +67,8 @@ var _ = Describe("rds controller", func() {
 			panic("$RAND_OWNER_PREFIX not set, failing test")
 		}
 
+		rdsInstanceName = fmt.Sprintf("%s-test-rds", randOwnerPrefix)
+
 		var err error
 		sess, err = session.NewSession(&aws.Config{
 			Region: aws.String("us-west-1"),
@@ -85,11 +88,8 @@ var _ = Describe("rds controller", func() {
 
 		rdsInstance = &dbv1beta1.RDSInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-rds",
+				Name:      rdsInstanceName,
 				Namespace: helpers.Namespace,
-			},
-			Spec: dbv1beta1.RDSInstanceSpec{
-				InstanceID: fmt.Sprintf("%s-test-rds", randOwnerPrefix),
 			},
 		}
 		// multiaz false should save some time in testing while being operationally similar to normal usage
@@ -116,10 +116,10 @@ var _ = Describe("rds controller", func() {
 		c.Create(rdsInstance)
 
 		fetchRDS := &dbv1beta1.RDSInstance{}
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusCreating), c.EventuallyTimeout(time.Minute*3))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusCreating), c.EventuallyTimeout(time.Minute*3))
 
 		// This process should max out at roughly 10 minutes
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*10))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*10))
 
 		fetchSecret := &corev1.Secret{}
 		c.Get(helpers.Name("test-rds.rds-user-password"), fetchSecret)
@@ -134,8 +134,8 @@ var _ = Describe("rds controller", func() {
 
 		// Test password recreation via deletion
 		c.Delete(fetchSecret)
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*2))
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*5))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*2))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*5))
 
 		c.Get(helpers.Name("test-rds.rds-user-password"), fetchSecret)
 		Expect(string(fetchSecret.Data["password"])).To(HaveLen(43))
@@ -169,8 +169,8 @@ var _ = Describe("rds controller", func() {
 		fetchRDS.Spec.Parameters = map[string]string{}
 		c.Update(fetchRDS)
 
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*3))
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*11))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*3))
+		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*11))
 
 		params, err := getDBParameters()
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/rds/controller_test.go
+++ b/pkg/controller/rds/controller_test.go
@@ -201,7 +201,7 @@ func runTestQuery(db *sql.DB) error {
 
 func dbInstanceExists() bool {
 	_, err := rdssvc.DescribeDBInstances(&rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(rdsInstance.Spec.InstanceID),
+		DBInstanceIdentifier: aws.String(rdsInstanceName),
 	})
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {

--- a/pkg/controller/rds/controller_test.go
+++ b/pkg/controller/rds/controller_test.go
@@ -122,7 +122,7 @@ var _ = Describe("rds controller", func() {
 		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*10))
 
 		fetchSecret := &corev1.Secret{}
-		c.Get(helpers.Name("test-rds.rds-user-password"), fetchSecret)
+		c.Get(helpers.Name(fmt.Sprintf("%s.rds-user-password", rdsInstanceName)), fetchSecret)
 		Expect(string(fetchSecret.Data["password"])).To(HaveLen(43))
 
 		testContext := components.NewTestContext(fetchSecret, nil)
@@ -137,7 +137,7 @@ var _ = Describe("rds controller", func() {
 		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*2))
 		c.EventuallyGet(helpers.Name(rdsInstanceName), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*5))
 
-		c.Get(helpers.Name("test-rds.rds-user-password"), fetchSecret)
+		c.Get(helpers.Name(fmt.Sprintf("%s.rds-user-password", rdsInstanceName)), fetchSecret)
 		Expect(string(fetchSecret.Data["password"])).To(HaveLen(43))
 
 		db2, err := postgres.Open(testContext, &fetchRDS.Status.Connection)

--- a/pkg/controller/rds/controller_test.go
+++ b/pkg/controller/rds/controller_test.go
@@ -61,10 +61,6 @@ var _ = Describe("rds controller", func() {
 			panic("$AWS_SUBNET_GROUP_NAME not set, failing test")
 		}
 
-		if os.Getenv("VPC_ID") == "" {
-			panic("$VPC_ID not set, failing test")
-		}
-
 		randOwnerPrefix = os.Getenv("RAND_OWNER_PREFIX")
 		if randOwnerPrefix == "" {
 			panic("$RAND_OWNER_PREFIX not set, failing test")

--- a/pkg/controller/rds/controller_test.go
+++ b/pkg/controller/rds/controller_test.go
@@ -116,9 +116,7 @@ var _ = Describe("rds controller", func() {
 		c.Create(rdsInstance)
 
 		fetchRDS := &dbv1beta1.RDSInstance{}
-		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusCreating), c.EventuallyTimeout(time.Minute*2))
-
-		//c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusModifying), c.EventuallyTimeout(time.Minute*2))
+		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusCreating), c.EventuallyTimeout(time.Minute*3))
 
 		// This process should max out at roughly 10 minutes
 		c.EventuallyGet(helpers.Name("test-rds"), fetchRDS, c.EventuallyStatus(dbv1beta1.StatusReady), c.EventuallyTimeout(time.Minute*10))

--- a/scripts/aws_cleanup/delete_operator_resources.go
+++ b/scripts/aws_cleanup/delete_operator_resources.go
@@ -290,8 +290,6 @@ func getRDSInstancesToDelete(rdssvc *rds.RDS, prefix string) ([]*string, error) 
 		match := regexp.MustCompile(regexString).Match([]byte(aws.StringValue(instance.DBInstanceIdentifier)))
 		if match {
 			dbInstancesToDelete = append(dbInstancesToDelete, instance.DBInstanceIdentifier)
-		} else {
-			fmt.Printf("wat: %s\n", aws.StringValue(instance.DBInstanceIdentifier))
 		}
 	}
 	return dbInstancesToDelete, nil


### PR DESCRIPTION
Allows use of an instance ID other than instance.Name

VPC_ID now derived from Spec.SubnetGroupName

Enabled encryption at rest with defaulted kms key (for now)

Test stability improvement


