### PR TITLE
Devops 1667 vanity aliases

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -60,6 +60,8 @@ type SummonPlatformSpec struct {
 	// Hostname to use for the instance. Defaults to $NAME.ridecell.us.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
+	// Hostname aliases (for vanity purposes)
+	Aliases []string `json:"aliases,omitempty"`
 	// Summon image version to deploy.
 	Version string `json:"version"`
 	// Name of the secret to use for secret values.

--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -61,6 +61,7 @@ type SummonPlatformSpec struct {
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 	// Hostname aliases (for vanity purposes)
+	// +optional
 	Aliases []string `json:"aliases,omitempty"`
 	// Summon image version to deploy.
 	Version string `json:"version"`

--- a/pkg/controller/summon/components/ingress_test.go
+++ b/pkg/controller/summon/components/ingress_test.go
@@ -18,7 +18,6 @@ package components_test
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
 	. "github.com/onsi/ginkgo"
@@ -37,6 +36,8 @@ var _ = Describe("SummonPlatform ingress Component", func() {
 		target := &k8sv1beta1.Ingress{}
 		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-web", Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
+		// There should only be a single rule (for the primary hostname -- no vanity hostname rules should exist)
+		Expect(target.Spec.Rules).To(HaveLen(1))
 	})
 
 	It("creates an ingress object using static template", func() {
@@ -63,8 +64,9 @@ var _ = Describe("SummonPlatform ingress Component", func() {
 		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-web", Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
 
+		// ensure each vanity hostname has the same ingress rules as the primary hostname
 		for _, vanityName := range instance.Spec.Aliases {
-			vanityRule := &k8sv1beta1.IngressRule{
+			vanityRule := k8sv1beta1.IngressRule{
 				Host:             vanityName,
 				IngressRuleValue: target.Spec.Rules[0].IngressRuleValue,
 			}

--- a/pkg/controller/summon/components/ingress_test.go
+++ b/pkg/controller/summon/components/ingress_test.go
@@ -54,4 +54,16 @@ var _ = Describe("SummonPlatform ingress Component", func() {
 		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-daphne", Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("creates an ingress object with rules for given aliases using web template", func() {
+		instance.Spec.Aliases = []string{"foo-1.ridecell.us", "foo-2.ridecell.us"}
+		comp := summoncomponents.NewIngress("web/ingress.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+		target := &k8sv1beta1.Ingress{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-web", Namespace: instance.Namespace}, target)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(target.Spec.Rules).To(HaveKeyWithValue("host", "foo.ridecell.us"))
+		Expect(target.Spec.Rules).To(HaveKeyWithValue("host", "foo-1.ridecell.us"))
+		Expect(target.Spec.Rules).To(HaveKeyWithValue("host", "foo-2.ridecell.us"))
+	})
 })

--- a/pkg/controller/summon/components/ingress_test.go
+++ b/pkg/controller/summon/components/ingress_test.go
@@ -38,6 +38,7 @@ var _ = Describe("SummonPlatform ingress Component", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// There should only be a single rule (for the primary hostname -- no vanity hostname rules should exist)
 		Expect(target.Spec.Rules).To(HaveLen(1))
+		Expect(target.Spec.TLS[0].Hosts).To(And(ContainElement(instance.Spec.Hostname), HaveLen(1)))
 	})
 
 	It("creates an ingress object using static template", func() {
@@ -71,6 +72,7 @@ var _ = Describe("SummonPlatform ingress Component", func() {
 				IngressRuleValue: target.Spec.Rules[0].IngressRuleValue,
 			}
 			Expect(target.Spec.Rules).To(ContainElement(vanityRule))
+			Expect(target.Spec.TLS[0].Hosts).To(ContainElement(vanityName))
 		}
 	})
 })

--- a/pkg/controller/summon/controller_test.go
+++ b/pkg/controller/summon/controller_test.go
@@ -343,6 +343,44 @@ var _ = Describe("Summon controller", func() {
 		}, timeout).Should(Succeed())
 	})
 
+	It("reconciles ingress service with specified vanity hostnames", func() {
+		c := helpers.TestClient
+		instance := &summonv1beta1.SummonPlatform{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: helpers.Namespace},
+			Spec: summonv1beta1.SummonPlatformSpec{
+				Hostname: "vanitytest.ridecell.us",
+				Aliases:  []string{"vanitytest-1.ridecell.us", "vanitytest-2.ridecell.us"},
+				Version:  "1.2.3",
+				Secrets:  []string{"testsecret"},
+				Database: summonv1beta1.DatabaseSpec{
+					ExclusiveDatabase: true,
+				},
+			}}
+
+		// Create the SummonPlatform object and expect the Reconcile to be created.
+		c.Create(instance)
+		c.Status().Update(instance)
+
+		// Check the web Service object.
+		service := &corev1.Service{}
+		c.EventuallyGet(helpers.Name("foo-web"), service)
+		Expect(service.Spec.Ports[0].Port).To(BeEquivalentTo(8000))
+
+		// Check the web Ingress object.
+		ingress := &extv1beta1.Ingress{}
+		c.EventuallyGet(helpers.Name("foo-web"), ingress)
+
+		Expect(ingress.Spec.TLS[0].SecretName).To(Equal("foo-tls"))
+
+		for _, vanityName := range instance.Spec.Aliases {
+			vanityRule := extv1beta1.IngressRule{
+				Host:             vanityName,
+				IngressRuleValue: ingress.Spec.Rules[0].IngressRuleValue,
+			}
+			Expect(ingress.Spec.Rules).To(ContainElement(vanityRule))
+			Expect(ingress.Spec.TLS[0].Hosts).To(ContainElement(vanityName))
+		}
+	})
+
 	It("manages the status correctly", func() {
 		c := helpers.Client
 

--- a/pkg/controller/summon/templates/helpers/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/ingress.yml.tpl
@@ -24,8 +24,20 @@ spec:
         backend:
           serviceName: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}
           servicePort: 8000
+  {{range .Instance.Spec.Aliases }}
+  - host: {{.}}
+    http:
+      paths:
+      - path: {{ block "ingressPath" . }}{{ end }}
+        backend:
+          serviceName: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}
+          servicePort: 8000
+    {{end}}
   tls:
   - secretName: {{ .Instance.Name }}-tls
     hosts:
     - {{ .Instance.Spec.Hostname }}
+    {{range .Instance.Spec.Aliases}}
+    - {{.}}
+    {{ end }}
 {{ end }}

--- a/pkg/controller/summon/templates/helpers/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/ingress.yml.tpl
@@ -31,11 +31,13 @@ spec:
       - path: {{ block "ingressPath" $ }}{{ end }}
         backend:
           serviceName: {{ $.Instance.Name }}-{{ block "componentName" $ }}{{ end }}
-          servicePort: 8000{{end}}
+          servicePort: 8000
+  {{- end }}
   tls:
   - secretName: {{ .Instance.Name }}-tls
     hosts:
     - {{ .Instance.Spec.Hostname }}
     {{- range .Instance.Spec.Aliases }}
-    - {{.}}{{ end }}
+    - {{.}}
+    {{- end }}
 {{ end }}

--- a/pkg/controller/summon/templates/helpers/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/ingress.yml.tpl
@@ -24,7 +24,8 @@ spec:
         backend:
           serviceName: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}
           servicePort: 8000
-  {{range .Instance.Spec.Aliases}}- host: {{.}}
+  {{- range .Instance.Spec.Aliases }}
+  - host: {{.}}
     http:
       paths:
       - path: {{ block "ingressPath" $ }}{{ end }}
@@ -35,6 +36,6 @@ spec:
   - secretName: {{ .Instance.Name }}-tls
     hosts:
     - {{ .Instance.Spec.Hostname }}
-    {{range .Instance.Spec.Aliases}}- {{.}}
-    {{ end }}
+    {{- range .Instance.Spec.Aliases }}
+    - {{.}}{{ end }}
 {{ end }}

--- a/pkg/controller/summon/templates/helpers/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/ingress.yml.tpl
@@ -24,20 +24,17 @@ spec:
         backend:
           serviceName: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}
           servicePort: 8000
-  {{range .Instance.Spec.Aliases }}
-  - host: {{.}}
+  {{range .Instance.Spec.Aliases}}- host: {{.}}
     http:
       paths:
-      - path: {{ block "ingressPath" . }}{{ end }}
+      - path: {{ block "ingressPath" $ }}{{ end }}
         backend:
-          serviceName: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}
-          servicePort: 8000
-    {{end}}
+          serviceName: {{ $.Instance.Name }}-{{ block "componentName" $ }}{{ end }}
+          servicePort: 8000{{end}}
   tls:
   - secretName: {{ .Instance.Name }}-tls
     hosts:
     - {{ .Instance.Spec.Hostname }}
-    {{range .Instance.Spec.Aliases}}
-    - {{.}}
+    {{range .Instance.Spec.Aliases}}- {{.}}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
1) Added `Aliases` to SummonPlatformSpec.
2) Modified `ingress.yml.tpl` to create IngressRule for each individual alias using the same service as the primary hostname.
3) Tested new changes in `ingress_type.go` and `controller_test.go`