### PR TITLE
Switch to an ObjectRef so we can more easily do cross-database DbConfig references

### DIFF
--- a/pkg/apis/db/v1beta1/postgresdatabase_types.go
+++ b/pkg/apis/db/v1beta1/postgresdatabase_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,9 +32,9 @@ type PostgresDatabaseSpec struct {
 	// Name of the user to own this database. Defaults to a user with the same name as `DatabaseName`.
 	// +optional
 	Owner string `json:"owner,omitempty"`
-	// An optional name of a DbConfig object in this namespace to use for configuration. Defaults to the name of the namespace.
+	// An optional ref to a DbConfig object to use for configuration. Defaults to the name of the namespace.
 	// +optional
-	DbConfig string `json:"dbConfig,omitempty"`
+	DbConfigRef corev1.ObjectReference `json:"dbConfigRef,omitempty"`
 	// A map of extensions to versions to install. If the version is "" then the latest version will be used.
 	// +optional
 	Extensions map[string]string `json:"extensions,omitempty"`

--- a/pkg/controller/postgresdatabase/components/defaults.go
+++ b/pkg/controller/postgresdatabase/components/defaults.go
@@ -48,9 +48,6 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	if instance.Spec.Owner == "" {
 		instance.Spec.Owner = instance.Spec.DatabaseName
 	}
-	if instance.Spec.DbConfig == "" {
-		instance.Spec.DbConfig = instance.Namespace
-	}
 
 	return components.Result{}, nil
 }

--- a/pkg/controller/postgresdatabase/controller_test.go
+++ b/pkg/controller/postgresdatabase/controller_test.go
@@ -238,8 +238,8 @@ var _ = Describe("PostgresDatabase controller", func() {
 		c := helpers.TestClient
 
 		// Set up the DbConfig.
-		dbconfig.ObjectMeta.Name = helpers.OperatorNamespace
-		dbconfig.ObjectMeta.Namespace = helpers.OperatorNamespace
+		dbconfig.Name = randomName
+		dbconfig.Namespace = helpers.OperatorNamespace
 		dbconfig.Spec.Postgres.Mode = "Shared"
 		dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
 			MaintenanceWindow: "Mon:00:00-Mon:01:00",
@@ -247,19 +247,19 @@ var _ = Describe("PostgresDatabase controller", func() {
 		c.Create(dbconfig)
 
 		// Create our database.
-		instance.Spec.DbConfigRef.Name = helpers.OperatorNamespace
+		instance.Spec.DbConfigRef.Name = randomName
 		instance.Spec.DbConfigRef.Namespace = helpers.OperatorNamespace
 		c.Create(instance)
 
 		// Get our RDS cluster and advance it to ready.
 		rds := &dbv1beta1.RDSInstance{}
-		c.EventuallyGet(types.NamespacedName{Name: randomName + "-dev", Namespace: helpers.OperatorNamespace}, rds)
+		c.EventuallyGet(types.NamespacedName{Name: randomName, Namespace: helpers.OperatorNamespace}, rds)
 		rds.Status.Status = dbv1beta1.StatusReady
 		rds.Status.Connection = *conn
 		c.Status().Update(rds)
 
 		// Wait for our database to become ready.
-		c.EventuallyGet(types.NamespacedName{Name: randomName + "-dev", Namespace: helpers.OperatorNamespace}, instance, c.EventuallyStatus(dbv1beta1.StatusReady))
+		c.EventuallyGet(helpers.Name(randomName+"-dev"), instance, c.EventuallyStatus(dbv1beta1.StatusReady))
 
 		// Check the output connection.
 		Expect(instance.Status.Connection.Database).ToNot(Equal("postgres"))
@@ -286,8 +286,8 @@ var _ = Describe("PostgresDatabase controller", func() {
 		c := helpers.TestClient
 
 		// Set up the DbConfig.
-		dbconfig.ObjectMeta.Name = helpers.OperatorNamespace
-		dbconfig.ObjectMeta.Namespace = helpers.OperatorNamespace
+		dbconfig.Name = randomName
+		dbconfig.Namespace = helpers.OperatorNamespace
 		dbconfig.Spec.Postgres.Mode = "Exclusive"
 		dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
 			MaintenanceWindow: "Mon:00:00-Mon:01:00",
@@ -295,7 +295,7 @@ var _ = Describe("PostgresDatabase controller", func() {
 		c.Create(dbconfig)
 
 		// Create our database.
-		instance.Spec.DbConfigRef.Name = helpers.OperatorNamespace
+		instance.Spec.DbConfigRef.Name = randomName
 		instance.Spec.DbConfigRef.Namespace = helpers.OperatorNamespace
 		c.Create(instance)
 

--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -69,7 +69,7 @@ func (comp *postgresComponent) WatchMap(obj handler.MapObject, c client.Client) 
 	}
 
 	requests := []reconcile.Request{}
-	// If we are in exclusive mode, check if the change is a linked DbConfig.
+	// If we are in PostgresDatabase, check if the change is a linked DbConfig.
 	_, isDbConfig := obj.Object.(*dbv1beta1.DbConfig)
 	if comp.mode == "Exclusive" && isDbConfig {
 		dbs := &dbv1beta1.PostgresDatabaseList{}
@@ -79,11 +79,6 @@ func (comp *postgresComponent) WatchMap(obj handler.MapObject, c client.Client) 
 		}
 
 		for _, db := range dbs.Items {
-			// TODO Can do this with a list option once that API stabilizes
-			if db.Namespace != obj.Meta.GetNamespace() {
-				continue
-			}
-
 			// Check the DbConfig field.
 			dbConfigRef := comp.dbConfigRefFor(&db)
 			if dbConfigRef.Name == obj.Meta.GetName() && dbConfigRef.Namespace == obj.Meta.GetNamespace() {

--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	postgresv1 "github.com/zalando-incubator/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -84,7 +85,8 @@ func (comp *postgresComponent) WatchMap(obj handler.MapObject, c client.Client) 
 			}
 
 			// Check the DbConfig field.
-			if (db.Spec.DbConfig == "" && obj.Meta.GetName() == db.Namespace) || db.Spec.DbConfig == obj.Meta.GetName() {
+			dbConfigRef := comp.dbConfigRefFor(&db)
+			if dbConfigRef.Name == obj.Meta.GetName() && dbConfigRef.Namespace == obj.Meta.GetNamespace() {
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: db.Name, Namespace: db.Namespace}})
 			}
 		}
@@ -102,10 +104,11 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 	if comp.mode == "Exclusive" {
 		// This is a PostgresDatabase so try to load the relevant DbConfig.
 		pqdb := ctx.Top.(*dbv1beta1.PostgresDatabase)
+		dbconfigRef := comp.dbConfigRefFor(pqdb)
 		dbconfig = &dbv1beta1.DbConfig{}
-		err := ctx.Get(ctx.Context, types.NamespacedName{Name: pqdb.Spec.DbConfig, Namespace: pqdb.Namespace}, dbconfig)
+		err := ctx.Get(ctx.Context, types.NamespacedName{Name: dbconfigRef.Name, Namespace: dbconfigRef.Namespace}, dbconfig)
 		if err != nil {
-			return components.Result{}, errors.Wrapf(err, "postgres: error getting dbconfig %s/%s for PostgresDatabase %s", pqdb.Namespace, pqdb.Spec.DbConfig, pqdb.Name)
+			return components.Result{}, errors.Wrapf(err, "postgres: error getting dbconfig %s/%s for PostgresDatabase %s", dbconfigRef.Namespace, dbconfigRef.Name, pqdb.Name)
 		}
 		// Do nothing in shared mode, DB is already provisioned.
 		if dbconfig.Spec.Postgres.Mode == "Shared" {
@@ -223,4 +226,16 @@ func (comp *postgresComponent) reconcileLocal(ctx *components.ComponentContext, 
 		Database: "postgres",
 	}
 	return res, existing.Status.String(), conn, nil
+}
+
+func (comp *postgresComponent) dbConfigRefFor(db *dbv1beta1.PostgresDatabase) *corev1.ObjectReference {
+	name := db.Spec.DbConfigRef.Name
+	if name == "" {
+		name = db.Namespace
+	}
+	namespace := db.Spec.DbConfigRef.Namespace
+	if namespace == "" {
+		namespace = db.Namespace
+	}
+	return &corev1.ObjectReference{Name: name, Namespace: namespace}
 }

--- a/pkg/controller/shared_components/postgres/postgres_test.go
+++ b/pkg/controller/shared_components/postgres/postgres_test.go
@@ -43,9 +43,6 @@ var _ = Describe("Postgres Shared Component", func() {
 		dbconfig = instance
 		pqdb = &dbv1beta1.PostgresDatabase{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo-dev", Namespace: "summon-dev"},
-			Spec: dbv1beta1.PostgresDatabaseSpec{
-				DbConfig: "summon-dev",
-			},
 		}
 	})
 


### PR DESCRIPTION
This will be needed for microservices.