### PR TITLE
Allow customizing the deployment status URL on a per-object basis.

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -36,6 +36,9 @@ type NotificationsSpec struct {
 	// Name of the slack channel for notifications. If not set, no notifications will be sent.
 	// +optional
 	SlackChannel string `json:"slackChannel,omitempty"`
+	// Override for the global default deployment-status server to use.
+	// +optional
+	DeploymentStatusUrl string `json:"deploymentStatusUrl,omitempty"`
 }
 
 // DatabaseSpec is used to specify whether we are using a shared database or not.

--- a/pkg/controller/summon/components/notification_test.go
+++ b/pkg/controller/summon/components/notification_test.go
@@ -45,7 +45,7 @@ var _ = Describe("SummonPlatform Notification Component", func() {
 		instance.Spec.Notifications.SlackChannel = "#test-channel"
 
 		mockedDeployStatusClient = &summoncomponents.DeployStatusClientMock{
-			PostStatusFunc: func(_, _, _ string) error {
+			PostStatusFunc: func(_, _, _, _ string) error {
 				return nil
 			},
 		}

--- a/pkg/controller/summon/controller_notification_test.go
+++ b/pkg/controller/summon/controller_notification_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Summon controller", func() {
 
 		BeforeEach(func() {
 			deployStatusServer = ghttp.NewServer()
-			os.Setenv("DEPLOY_STAT_URL", deployStatusServer.URL())
+			instance.Spec.Notifications.DeploymentStatusUrl = deployStatusServer.URL()
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
This allows for better testing isolation, and should avoid the cross-talk flake that we have been seeing.