### PR TITLE
Allow overriding the RDS instance ID for a database

### DIFF
--- a/pkg/apis/db/v1beta1/dbconfig_types.go
+++ b/pkg/apis/db/v1beta1/dbconfig_types.go
@@ -62,9 +62,10 @@ type LocalPostgresSpec struct {
 
 type PostgresDbConfig struct {
 	// +kubebuilder:validation:Enum=Exclusive,Shared
-	Mode  string             `json:"mode"`
-	RDS   *RDSInstanceSpec   `json:"rds,omitempty"`
-	Local *LocalPostgresSpec `json:"local,omitempty"`
+	Mode        string             `json:"mode"`
+	RDS         *RDSInstanceSpec   `json:"rds,omitempty"`
+	RDSOverride map[string]string  `json:"rdsOverride,omitempty"`
+	Local       *LocalPostgresSpec `json:"local,omitempty"`
 }
 
 // DbConfigSpec defines the desired state of DbConfig

--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -161,6 +161,14 @@ func (comp *postgresComponent) reconcileRDS(ctx *components.ComponentContext, db
 	extras := map[string]interface{}{
 		"DbConfig": dbconfig,
 	}
+
+	// If an override is present, insert it into the RDSSpec.
+	metaObj := ctx.Top.(metav1.Object)
+	id, ok := dbconfig.Spec.Postgres.RDSOverride[metaObj.GetName()]
+	if ok {
+		dbconfig.Spec.Postgres.RDS.InstanceID = id
+	}
+
 	var existing *dbv1beta1.RDSInstance
 	res, _, err := ctx.WithTemplates(Templates).CreateOrUpdate("rds.yml.tpl", extras, func(goalObj, existingObj runtime.Object) error {
 		goal := goalObj.(*dbv1beta1.RDSInstance)

--- a/pkg/controller/shared_components/postgres/postgres_test.go
+++ b/pkg/controller/shared_components/postgres/postgres_test.go
@@ -67,6 +67,8 @@ var _ = Describe("Postgres Shared Component", func() {
 			err := ctx.Get(context.Background(), types.NamespacedName{Name: "summon-dev-database", Namespace: "summon-dev"}, postgres)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(postgres.Spec.TeamID).To(Equal("summon-dev"))
+			Expect(postgres.Spec.NumberOfInstances).To(BeNumerically("==", 2))
+			Expect(postgres.Spec.Users).To(HaveKeyWithValue("ridecell-admin", BeEquivalentTo([]string{"superuser"})))
 			Expect(dbconfig.Status.Postgres.Connection.Host).To(Equal("summon-dev-database"))
 		})
 
@@ -80,6 +82,7 @@ var _ = Describe("Postgres Shared Component", func() {
 			rds := &dbv1beta1.RDSInstance{}
 			err := ctx.Get(context.Background(), types.NamespacedName{Name: "summon-dev", Namespace: "summon-dev"}, rds)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(rds.Spec.MaintenanceWindow).To(Equal("Mon:00:00-Mon:01:00"))
 		})
 	})
 

--- a/pkg/controller/shared_components/postgres/templates/local.yml.tpl
+++ b/pkg/controller/shared_components/postgres/templates/local.yml.tpl
@@ -3,5 +3,30 @@ kind: postgresql
 metadata:
   name: {{ .Instance.Name }}-database
   namespace: {{ .Instance.Namespace }}
-# This is filled in from the object.
-spec: {}
+spec:
+  {{/* Copy over fields. */}}
+  {{ $local := .Extra.DbConfig.Spec.Postgres.Local }}
+  postgresql:
+    version: {{ $local.PostgresqlParam.PgVersion | quote }}
+    parameters: {{ $local.PostgresqlParam.Parameters | toJson }}
+  volume: {{ $local.Volume | toJson }}
+  resources: {{ $local.Resources | toJson }}
+  dockerImage: {{ $local.DockerImage | quote }}
+  enableMasterLoadBalancer: {{ $local.EnableMasterLoadBalancer | toJson }}
+  enableReplicaLoadBalancer: {{ $local.EnableReplicaLoadBalancer | toJson }}
+  allowedSourceRanges: {{ $local.AllowedSourceRanges | toJson }}
+  maintenanceWindows: {{ $local.MaintenanceWindows | toJson }}
+  clone: {{ $local.Clone | toJson }}
+  databases: {{ $local.Databases | toJson }} {{/* Handled by us, so usually empty */}}
+  tolerations: {{ $local.Tolerations | toJson }}
+  sidecars: {{ $local.Sidecars | toJson }}
+  pod_priority_class_name: {{ $local.PodPriorityClassName | quote }}
+
+  {{/* Fields we care about */}}
+  teamId: {{ .Instance.Name }}
+  numberOfInstances: {{ $local.NumberOfInstances | default 2 }}
+  users:
+    {{ range $user, $flags := $local.Users }}
+    {{ $user }}: {{ $flags | toJson }}
+    {{ end }}
+    ridecell-admin: [superuser]

--- a/pkg/controller/shared_components/postgres/templates/rds.yml.tpl
+++ b/pkg/controller/shared_components/postgres/templates/rds.yml.tpl
@@ -3,5 +3,4 @@ kind: RDSInstance
 metadata:
   name: {{ .Instance.Name }}
   namespace: {{ .Instance.Namespace }}
-# This is filled in from the object.
-spec: {}
+spec: {{ .Extra.DbConfig.Spec.Postgres.RDS | toJson }}


### PR DESCRIPTION
Mostly matters for restoring from backups but maybe for migrating existing summon prod instances where the ID doesn't match our standard format.