### PR TITLE
Copy AccessModes and StorageClassName to pvc

### DIFF
--- a/pkg/controller/summon/components/pvc.go
+++ b/pkg/controller/summon/components/pvc.go
@@ -47,6 +47,8 @@ func (comp *pvcComponent) Reconcile(ctx *components.ComponentContext) (component
 		existing := existingObj.(*corev1.PersistentVolumeClaim)
 		// Copy the Spec over.
 		existing.Spec.Resources.Requests = goal.Spec.Resources.Requests
+		existing.Spec.AccessModes = goal.Spec.AccessModes
+		existing.Spec.StorageClassName = goal.Spec.StorageClassName
 		return nil
 	})
 	return res, err


### PR DESCRIPTION
These values need to be copied over in the case of a new PVC