### PR TITLE
Add support for a migration override on the RDS master username too.

### DIFF
--- a/pkg/apis/db/v1beta1/postgresdatabase_types.go
+++ b/pkg/apis/db/v1beta1/postgresdatabase_types.go
@@ -21,6 +21,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// MigrationOverridesSpec defines value overrides used when migrating Ansible-based Summon instances into Kubernetes/ridecell-operator.
+type MigrationOverridesSpec struct {
+	// An optional RDS instance ID override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
+	// +optional
+	RDSInstanceID string `json:"rdsInstanceId,omitempty"`
+	// An optional RDS master username override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
+	// +optional
+	RDSMasterUsername string `json:"rdsMasterUsername,omitempty"`
+}
+
 // PostgresDatabaseSpec defines the desired state of PostgresDatabase
 type PostgresDatabaseSpec struct {
 	// Name of the database to create. Defaults the same name as the PostgresDatabase object.
@@ -38,9 +48,9 @@ type PostgresDatabaseSpec struct {
 	// A map of extensions to versions to install. If the version is "" then the latest version will be used.
 	// +optional
 	Extensions map[string]string `json:"extensions,omitempty"`
-	// An optional RDS instance ID override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
+	// Migration override settings.
 	// +optional
-	OverrideRDSInstanceID string `json:"overrideRdsInstanceId,omitempty"`
+	MigrationOverrides MigrationOverridesSpec `json:"migrationOverrides,omitempty"`
 }
 
 // PostgresDatabaseStatus defines the observed state of PostgresDatabase

--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -75,11 +75,12 @@ type WaitSpec struct {
 
 // MigrationOverridesSpec defines value overrides used when migrating Ansible-based Summon instances into Kubernetes/ridecell-operator.
 type MigrationOverridesSpec struct {
-	RDSInstanceID    string `json:"rdsInstanceId,omitempty"`
-	PostgresDatabase string `json:"postgresDatabase,omitempty"`
-	PostgresUsername string `json:"postgresUsername,omitempty"`
-	RabbitMQVhost    string `json:"rabbitmqVhost,omitempty"`
-	RedisHostname    string `json:"redisHostname,omitempty"`
+	RDSInstanceID     string `json:"rdsInstanceId,omitempty"`
+	RDSMasterUsername string `json:"rdsMasterUsername,omitempty"`
+	PostgresDatabase  string `json:"postgresDatabase,omitempty"`
+	PostgresUsername  string `json:"postgresUsername,omitempty"`
+	RabbitMQVhost     string `json:"rabbitmqVhost,omitempty"`
+	RedisHostname     string `json:"redisHostname,omitempty"`
 }
 
 // SummonPlatformSpec defines the desired state of SummonPlatform

--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -102,7 +102,7 @@ func (_ *postgresComponent) IsReconcilable(ctx *components.ComponentContext) boo
 
 func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (components.Result, error) {
 	var dbconfig *dbv1beta1.DbConfig
-	var overrideRdsInstanceID string
+	var migrationOverrides *dbv1beta1.MigrationOverridesSpec
 	if comp.mode == "Exclusive" {
 		// This is a PostgresDatabase so try to load the relevant DbConfig.
 		pqdb := ctx.Top.(*dbv1beta1.PostgresDatabase)
@@ -122,7 +122,7 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 				return nil
 			}}, nil
 		}
-		overrideRdsInstanceID = pqdb.Spec.OverrideRDSInstanceID
+		migrationOverrides = &pqdb.Spec.MigrationOverrides
 	} else {
 		dbconfig = ctx.Top.(*dbv1beta1.DbConfig)
 		// Do nothing in exclusive mode, DB will be provisioned by PostgresDatabase.
@@ -137,7 +137,7 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 	var rdsInstanceID string
 	if dbconfig.Spec.Postgres.RDS != nil {
 		var rdsStatus *dbv1beta1.RDSInstanceStatus
-		res, rdsStatus, conn, err = comp.reconcileRDS(ctx, dbconfig, overrideRdsInstanceID)
+		res, rdsStatus, conn, err = comp.reconcileRDS(ctx, dbconfig, migrationOverrides)
 		status = rdsStatus.Status
 		rdsInstanceID = rdsStatus.InstanceID
 
@@ -188,13 +188,18 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 	return res, nil
 }
 
-func (comp *postgresComponent) reconcileRDS(ctx *components.ComponentContext, config *dbv1beta1.DbConfig, overrideRdsInstanceID string) (components.Result, *dbv1beta1.RDSInstanceStatus, *dbv1beta1.PostgresConnection, error) {
+func (comp *postgresComponent) reconcileRDS(ctx *components.ComponentContext, config *dbv1beta1.DbConfig, migrationOverrides *dbv1beta1.MigrationOverridesSpec) (components.Result, *dbv1beta1.RDSInstanceStatus, *dbv1beta1.PostgresConnection, error) {
 	var existing *dbv1beta1.RDSInstance
 	res, _, err := ctx.WithTemplates(Templates).CreateOrUpdate("rds.yml.tpl", nil, func(_goalObj, existingObj runtime.Object) error {
 		existing = existingObj.(*dbv1beta1.RDSInstance)
 		existing.Spec = *config.Spec.Postgres.RDS
-		if overrideRdsInstanceID != "" {
-			existing.Spec.InstanceID = overrideRdsInstanceID
+		if migrationOverrides != nil {
+			if migrationOverrides.RDSInstanceID != "" {
+				existing.Spec.InstanceID = migrationOverrides.RDSInstanceID
+			}
+			if migrationOverrides.RDSMasterUsername != "" {
+				existing.Spec.Username = migrationOverrides.RDSMasterUsername
+			}
 		}
 		return nil
 	})

--- a/pkg/controller/shared_components/postgres/postgres_test.go
+++ b/pkg/controller/shared_components/postgres/postgres_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Postgres Shared Component", func() {
 				dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
 					MaintenanceWindow: "Mon:00:00-Mon:01:00",
 				}
-				pqdb.Spec.OverrideRDSInstanceID = "legacy"
+				pqdb.Spec.MigrationOverrides.RDSInstanceID = "legacy"
 				ctx.Client = fake.NewFakeClient(dbconfig, pqdb)
 			})
 
@@ -284,6 +284,27 @@ var _ = Describe("Postgres Shared Component", func() {
 				err := ctx.Get(context.Background(), types.NamespacedName{Name: "foo-dev", Namespace: "summon-dev"}, rds)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rds.Spec.InstanceID).To(Equal("legacy"))
+			})
+		})
+
+		Context("with an RDS username override", func() {
+			BeforeEach(func() {
+				dbconfig.Spec.Postgres.Mode = "Exclusive"
+				dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
+					MaintenanceWindow: "Mon:00:00-Mon:01:00",
+				}
+				pqdb.Spec.MigrationOverrides.RDSMasterUsername = "root"
+				ctx.Client = fake.NewFakeClient(dbconfig, pqdb)
+			})
+
+			It("creates the RDS database with the override", func() {
+				ctx.Client = fake.NewFakeClient(dbconfig, pqdb)
+				Expect(comp).To(ReconcileContext(ctx))
+
+				rds := &dbv1beta1.RDSInstance{}
+				err := ctx.Get(context.Background(), types.NamespacedName{Name: "foo-dev", Namespace: "summon-dev"}, rds)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rds.Spec.Username).To(Equal("root"))
 			})
 		})
 	})

--- a/pkg/controller/summon/components/postgres_test.go
+++ b/pkg/controller/summon/components/postgres_test.go
@@ -107,7 +107,22 @@ var _ = Describe("SummonPlatform Postgres Component", func() {
 				db := &dbv1beta1.PostgresDatabase{}
 				err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo", Namespace: "default"}, db)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(db.Spec.OverrideRDSInstanceID).To(Equal("legacy"))
+				Expect(db.Spec.MigrationOverrides.RDSInstanceID).To(Equal("legacy"))
+			})
+		})
+
+		Context("with database master username migration override", func() {
+			BeforeEach(func() {
+				instance.Spec.MigrationOverrides.RDSInstanceID = "legacy"
+				instance.Spec.MigrationOverrides.RDSMasterUsername = "root"
+			})
+
+			It("sets the DatabaseName correctly", func() {
+				Expect(comp).To(ReconcileContext(ctx))
+				db := &dbv1beta1.PostgresDatabase{}
+				err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo", Namespace: "default"}, db)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(db.Spec.MigrationOverrides.RDSMasterUsername).To(Equal("root"))
 			})
 		})
 	})

--- a/pkg/controller/summon/templates/postgres_database.yml.tpl
+++ b/pkg/controller/summon/templates/postgres_database.yml.tpl
@@ -22,5 +22,10 @@ spec:
   skipUser: true
   {{ end }}
   {{ if .Instance.Spec.MigrationOverrides.RDSInstanceID }}
-  overrideRdsInstanceId: {{ .Instance.Spec.MigrationOverrides.RDSInstanceID }}
+  migrationOverrides:
+    rdsInstanceId: {{ .Instance.Spec.MigrationOverrides.RDSInstanceID }}
+    {{ if .Instance.Spec.MigrationOverrides.RDSMasterUsername }}
+    rdsMasterUsername: {{ .Instance.Spec.MigrationOverrides.RDSMasterUsername }}
+    {{ end }}
   {{ end }}
+


### PR DESCRIPTION
It's set to "root" for most of our TF databases. I pulled stuff into a struct since having two loose strings was weird and gross.