### PR TITLE
Add readiness and liveness probes for twisted.

### DIFF
--- a/pkg/controller/summon/controller_test.go
+++ b/pkg/controller/summon/controller_test.go
@@ -187,8 +187,11 @@ var _ = Describe("Summon controller", func() {
 		deploy := &appsv1.Deployment{}
 		c.EventuallyGet(helpers.Name("foo-web"), deploy)
 		Expect(deploy.Spec.Replicas).To(PointTo(BeEquivalentTo(1)))
-		Expect(deploy.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"python", "-m", "twisted", "--log-format", "text", "web", "--listen", "tcp:8000", "--wsgi", "summon_platform.wsgi.application"}))
-		Expect(deploy.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(BeEquivalentTo(8000))
+		Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+		container := deploy.Spec.Template.Spec.Containers[0]
+		Expect(container.Command).To(Equal([]string{"python", "-m", "twisted", "--log-format", "text", "web", "--listen", "tcp:8000", "--wsgi", "summon_platform.wsgi.application"}))
+		Expect(container.Ports[0].ContainerPort).To(BeEquivalentTo(8000))
+		Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/healthz"))
 
 		// Check the web Service object.
 		service := &corev1.Service{}

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -64,6 +64,7 @@ spec:
         - name: newrelic
           mountPath: /home/ubuntu/summon-platform
         {{ end }}
+        {{ block "containerExtra" . }}{{ end }}
       volumes:
         - name: config-volume
           configMap:

--- a/pkg/controller/summon/templates/web/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/web/deployment.yml.tpl
@@ -3,4 +3,16 @@
 {{ define "command" }}[python, -m, twisted, --log-format, text, web, --listen, tcp:8000, --wsgi, summon_platform.wsgi.application]{{ end }}
 {{ define "replicas" }}{{ .Instance.Spec.WebReplicas }}{{ end }}
 {{ define "memory_limit" }}2G{{ end }}
+{{ define "containerExtra" }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 60
+{{ end }}
 {{ template "deployment" . }}


### PR DESCRIPTION
This will help avoid cutouts where new pods are put in rotation before they are responding, because our app takes like 15 seconds to load.