### PR TITLE
Features for migrating shared DBs

### DIFF
--- a/pkg/apis/db/v1beta1/dbconfig_types.go
+++ b/pkg/apis/db/v1beta1/dbconfig_types.go
@@ -73,6 +73,9 @@ type DbConfigSpec struct {
 	// Create a periscope user for postgres db. Defaults to true.
 	// +optional
 	NoCreatePeriscopeUser bool `json:"noCreatePeriscopeUser,omitempty"`
+	// Migration override settings.
+	// +optional
+	MigrationOverrides MigrationOverridesSpec `json:"migrationOverrides,omitempty"`
 	// TODO RabbitMQ stuff too.
 }
 

--- a/pkg/apis/db/v1beta1/postgresdatabase_types.go
+++ b/pkg/apis/db/v1beta1/postgresdatabase_types.go
@@ -21,16 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MigrationOverridesSpec defines value overrides used when migrating Ansible-based Summon instances into Kubernetes/ridecell-operator.
-type MigrationOverridesSpec struct {
-	// An optional RDS instance ID override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
-	// +optional
-	RDSInstanceID string `json:"rdsInstanceId,omitempty"`
-	// An optional RDS master username override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
-	// +optional
-	RDSMasterUsername string `json:"rdsMasterUsername,omitempty"`
-}
-
 // PostgresDatabaseSpec defines the desired state of PostgresDatabase
 type PostgresDatabaseSpec struct {
 	// Name of the database to create. Defaults the same name as the PostgresDatabase object.

--- a/pkg/apis/db/v1beta1/types.go
+++ b/pkg/apis/db/v1beta1/types.go
@@ -55,3 +55,13 @@ type RabbitmqStatusConnection struct {
 type SharedUsersStatus struct {
 	Periscope string `json:"periscope"`
 }
+
+// MigrationOverridesSpec defines value overrides used when migrating Ansible-based Summon instances into Kubernetes/ridecell-operator.
+type MigrationOverridesSpec struct {
+	// An optional RDS instance ID override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
+	// +optional
+	RDSInstanceID string `json:"rdsInstanceId,omitempty"`
+	// An optional RDS master username override. Only used if the DbConfig is in RDS mode. Exists for migrations from Ansible Summon.
+	// +optional
+	RDSMasterUsername string `json:"rdsMasterUsername,omitempty"`
+}

--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -44,12 +44,8 @@ type NotificationsSpec struct {
 	DeploymentStatusUrl string `json:"deploymentStatusUrl,omitempty"`
 }
 
-// DatabaseSpec is used to specify whether we are using a shared database or not.
+// DatabaseSpec defines database-related configuration.
 type DatabaseSpec struct {
-	// +optional
-	ExclusiveDatabase bool `json:"exclusiveDatabase,omitempty"`
-	// +optional
-	SharedDatabaseName string `json:"sharedDatabaseName,omitempty"`
 }
 
 // CelerySpec defines configuration and settings for Celery.

--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -19,8 +19,10 @@ package v1beta1
 import (
 	"time"
 
-	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dbv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/db/v1beta1"
 )
 
 // Gross workaround for limitations the Kubernetes code generator and interface{}.
@@ -46,6 +48,9 @@ type NotificationsSpec struct {
 
 // DatabaseSpec defines database-related configuration.
 type DatabaseSpec struct {
+	// An optional ref to a DbConfig object to use for configuration. Defaults to the name of the namespace.
+	// +optional
+	DbConfigRef corev1.ObjectReference `json:"dbConfigRef,omitempty"`
 }
 
 // CelerySpec defines configuration and settings for Celery.

--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -131,6 +131,7 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 		if dbconfig.Spec.Postgres.Mode == "Exclusive" {
 			return components.Result{}, nil
 		}
+		migrationOverrides = &dbconfig.Spec.MigrationOverrides
 	}
 	var res components.Result
 	var status string

--- a/pkg/controller/shared_components/postgres/postgres_test.go
+++ b/pkg/controller/shared_components/postgres/postgres_test.go
@@ -146,6 +146,46 @@ var _ = Describe("Postgres Shared Component", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(pguser).To(Equal(&dbv1beta1.PostgresUser{}))
 		})
+
+		Context("with an RDS ID override", func() {
+			BeforeEach(func() {
+				dbconfig.Spec.Postgres.Mode = "Shared"
+				dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
+					MaintenanceWindow: "Mon:00:00-Mon:01:00",
+				}
+				dbconfig.Spec.NoCreatePeriscopeUser = true
+				dbconfig.Spec.MigrationOverrides.RDSInstanceID = "legacy"
+			})
+
+			It("creates the RDS database with the override", func() {
+				Expect(comp).To(ReconcileContext(ctx))
+
+				rds := &dbv1beta1.RDSInstance{}
+				err := ctx.Get(context.Background(), types.NamespacedName{Name: "summon-dev", Namespace: "summon-dev"}, rds)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rds.Spec.InstanceID).To(Equal("legacy"))
+			})
+		})
+
+		Context("with an RDS username override", func() {
+			BeforeEach(func() {
+				dbconfig.Spec.Postgres.Mode = "Shared"
+				dbconfig.Spec.Postgres.RDS = &dbv1beta1.RDSInstanceSpec{
+					MaintenanceWindow: "Mon:00:00-Mon:01:00",
+				}
+				dbconfig.Spec.NoCreatePeriscopeUser = true
+				dbconfig.Spec.MigrationOverrides.RDSMasterUsername = "root"
+			})
+
+			It("creates the RDS database with the override", func() {
+				Expect(comp).To(ReconcileContext(ctx))
+
+				rds := &dbv1beta1.RDSInstance{}
+				err := ctx.Get(context.Background(), types.NamespacedName{Name: "summon-dev", Namespace: "summon-dev"}, rds)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rds.Spec.Username).To(Equal("root"))
+			})
+		})
 	})
 
 	Context("with top being PostgresDatabase", func() {

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -97,9 +97,6 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	if instance.Spec.SQSRegion == "" {
 		instance.Spec.SQSRegion = "us-west-2"
 	}
-	if instance.Spec.Database.SharedDatabaseName == "" {
-		instance.Spec.Database.SharedDatabaseName = instance.Namespace
-	}
 
 	if instance.Spec.Environment == "uat" || instance.Spec.Environment == "prod" {
 		defConfig("FIREBASE_APP", "ridecell")

--- a/pkg/controller/summon/components/deployment_test.go
+++ b/pkg/controller/summon/components/deployment_test.go
@@ -189,7 +189,7 @@ var _ = Describe("deployment Component", func() {
 		Expect(target.Spec.Replicas).To(PointTo(BeEquivalentTo(0)))
 	})
 
-	FContext("with celeryd", func() {
+	Context("with celeryd", func() {
 		BeforeEach(func() {
 			comp = summoncomponents.NewDeployment("celeryd/deployment.yml.tpl")
 		})

--- a/pkg/controller/summon/components/postgres_test.go
+++ b/pkg/controller/summon/components/postgres_test.go
@@ -125,5 +125,20 @@ var _ = Describe("SummonPlatform Postgres Component", func() {
 				Expect(db.Spec.MigrationOverrides.RDSMasterUsername).To(Equal("root"))
 			})
 		})
+
+		Context("with a DbConfigRef", func() {
+			BeforeEach(func() {
+				instance.Spec.Database.DbConfigRef.Name = "weirddb"
+			})
+
+			It("sets the DbConfigRef correctly", func() {
+				Expect(comp).To(ReconcileContext(ctx))
+				db := &dbv1beta1.PostgresDatabase{}
+				err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo-dev", Namespace: "summon-dev"}, db)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(db.Spec.DbConfigRef.Name).To(Equal("weirddb"))
+			})
+		})
+
 	})
 })

--- a/pkg/controller/summon/controller_appsecrets_test.go
+++ b/pkg/controller/summon/controller_appsecrets_test.go
@@ -142,9 +142,6 @@ var _ = Describe("Summon controller appsecrets", func() {
 			Spec: summonv1beta1.SummonPlatformSpec{
 				Version: "80813-eb6b515-master",
 				Secrets: []string{},
-				Database: summonv1beta1.DatabaseSpec{
-					ExclusiveDatabase: true,
-				},
 			},
 		}
 	})

--- a/pkg/controller/summon/controller_notification_test.go
+++ b/pkg/controller/summon/controller_notification_test.go
@@ -63,9 +63,6 @@ var _ = Describe("Summon controller notifications", func() {
 			Spec: summonv1beta1.SummonPlatformSpec{
 				Version: "80813-eb6b515-master",
 				Secrets: []string{"testsecret"},
-				Database: summonv1beta1.DatabaseSpec{
-					ExclusiveDatabase: true,
-				},
 			},
 		}
 	})

--- a/pkg/controller/summon/controller_test.go
+++ b/pkg/controller/summon/controller_test.go
@@ -70,11 +70,6 @@ var _ = Describe("Summon controller", func() {
 		c := helpers.Client
 		instance := &summonv1beta1.SummonPlatform{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: helpers.Namespace},
-			Spec: summonv1beta1.SummonPlatformSpec{
-				Database: summonv1beta1.DatabaseSpec{
-					ExclusiveDatabase: true,
-				},
-			},
 		}
 		depKey := types.NamespacedName{Name: "foo-web", Namespace: helpers.Namespace}
 
@@ -98,9 +93,6 @@ var _ = Describe("Summon controller", func() {
 		instance := &summonv1beta1.SummonPlatform{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: helpers.Namespace}, Spec: summonv1beta1.SummonPlatformSpec{
 			Version: "1.2.3",
 			Secrets: []string{"testsecret"},
-			Database: summonv1beta1.DatabaseSpec{
-				ExclusiveDatabase: true,
-			},
 		}}
 
 		// Create the SummonPlatform object and expect the Reconcile to be created.
@@ -215,9 +207,6 @@ var _ = Describe("Summon controller", func() {
 			Spec: summonv1beta1.SummonPlatformSpec{
 				Version: "1.2.3",
 				Secrets: []string{"testsecret"},
-				Database: summonv1beta1.DatabaseSpec{
-					ExclusiveDatabase: true,
-				},
 			},
 			Status: summonv1beta1.SummonPlatformStatus{
 				MigrateVersion: "1.2.3",
@@ -355,9 +344,6 @@ var _ = Describe("Summon controller", func() {
 			Spec: summonv1beta1.SummonPlatformSpec{
 				Version: "1-abcdef1-master",
 				Secrets: []string{"statustester"},
-				Database: summonv1beta1.DatabaseSpec{
-					ExclusiveDatabase: true,
-				},
 			},
 		}
 		err := c.Create(context.TODO(), instance)

--- a/pkg/controller/summon/templates/postgres_database.yml.tpl
+++ b/pkg/controller/summon/templates/postgres_database.yml.tpl
@@ -14,6 +14,7 @@ spec:
   extensions:
     postgis: ""
     postgis_topology: ""
+  dbConfigRef: {{ .Instance.Spec.Database.DbConfigRef | toJson }}
   {{ if .Instance.Spec.MigrationOverrides.PostgresDatabase }}
   databaseName: {{ .Instance.Spec.MigrationOverrides.PostgresDatabase }}
   {{ end }}


### PR DESCRIPTION
We can create a Shared-mode DbConfig for the legacy DB and then point the summons at it.