### PR TITLE
Fix error handling. Corrects the crash we just saw in aws-us-prod.

### DIFF
--- a/pkg/controller/shared_components/postgres/postgres.go
+++ b/pkg/controller/shared_components/postgres/postgres.go
@@ -141,16 +141,18 @@ func (comp *postgresComponent) Reconcile(ctx *components.ComponentContext) (comp
 	if dbconfig.Spec.Postgres.RDS != nil {
 		var rdsStatus *dbv1beta1.RDSInstanceStatus
 		res, rdsStatus, conn, err = comp.reconcileRDS(ctx, dbconfig, migrationOverrides)
+		if err != nil {
+			return res, errors.Wrap(err, "error while reconciling RDS")
+		}
 		status = rdsStatus.Status
 		rdsInstanceID = rdsStatus.InstanceID
-
 	} else if dbconfig.Spec.Postgres.Local != nil {
 		res, status, conn, err = comp.reconcileLocal(ctx, dbconfig)
+		if err != nil {
+			return res, errors.Wrap(err, "error while reconciling local database")
+		}
 	} else {
 		return components.Result{}, errors.New("unexpected error, postgres database is not a known type")
-	}
-	if err != nil {
-		return res, err
 	}
 
 	_, err = comp.reconcileExporter(ctx, conn)


### PR DESCRIPTION
Relevant crash just for future searching:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x11addef]

goroutine 652 [running]:
github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x1bb3fa0, 0x33f5e70)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/Ridecell/ridecell-operator/pkg/controller/shared_components/postgres.(*postgresComponent).Reconcile(0xc0009d7df0, 0xc0019d6050, 0x0, 0x0, 0x221cc00, 0x342f2d0, 0x0)
	/go/src/github.com/Ridecell/ridecell-operator/pkg/controller/shared_components/postgres/postgres.go:144 +0x95f
github.com/Ridecell/ridecell-operator/pkg/components.(*componentReconciler).reconcileComponents(0xc0009de200, 0xc0019d6050, 0xc000184480, 0xc0018390c0, 0xb)
	/go/src/github.com/Ridecell/ridecell-operator/pkg/components/reconciler.go:221 +0x33c
github.com/Ridecell/ridecell-operator/pkg/components.(*componentReconciler).Reconcile(0xc0009de200, 0xc0018390e0, 0xb, 0xc0018390c0, 0xb, 0xc00253fa80, 0x0, 0x0, 0x0)
	/go/src/github.com/Ridecell/ridecell-operator/pkg/components/reconciler.go:148 +0x272
github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007fb9a0, 0xc001c35a00)
	/go/src/github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215 +0x20a
github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1()
	/go/src/github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158 +0x36
github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0024161e0)
	/go/src/github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x5e
github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0024161e0, 0x3b9aca00, 0x0, 0x1, 0xc00082c2a0)
	/go/src/github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134 +0xf8
github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0xc0024161e0, 0x3b9aca00, 0xc00082c2a0)
	/go/src/github.com/Ridecell/ridecell-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start
	/go/src/github.com/Ridecell/ridecell-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:157 +0x32e
```