### PR TITLE
Add support for the new web runtime goop

### DIFF
--- a/pkg/controller/summon/templates/web/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/web/deployment.yml.tpl
@@ -1,6 +1,6 @@
 {{ define "componentName" }}web{{ end }}
 {{ define "componentType" }}web{{ end }}
-{{ define "command" }}[python, -m, twisted, --log-format, text, web, --listen, tcp:8000, --wsgi, summon_platform.wsgi.application]{{ end }}
+{{ define "command" }}[sh, -c, "if [ -e summon_platform/__main__.py ]; then exec python -m summon_platform; else exec python -m twisted --log-format text web --listen tcp:8000 --wsgi summon_platform.wsgi.application; fi"]{{ end }}
 {{ define "replicas" }}{{ .Instance.Spec.Replicas.Web | default 0 }}{{ end }}
 {{ define "memory_limit" }}2G{{ end }}
 {{ define "containerExtra" }}


### PR DESCRIPTION
Requires https://github.com/Ridecell/summon-platform/pull/10500). With backwards compat for older versions because that __main__.py file is new.