### PR TITLE
defConfig modifies the static global defaults. defVal is the per-instance defaults helper

### DIFF
--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -104,10 +104,6 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		}
 	}
 
-	if instance.Spec.Environment == "uat" || instance.Spec.Environment == "prod" {
-		defConfig("FIREBASE_APP", "ridecell")
-	}
-
 	if instance.Spec.EnableNewRelic == nil && instance.Spec.Environment == "prod" {
 		val := true
 		instance.Spec.EnableNewRelic = &val
@@ -180,6 +176,9 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	// Set our gateway environment for GATEWAY_BASE_URL
 	gatewayEnv := "prod"
 
+	if instance.Spec.Environment == "uat" || instance.Spec.Environment == "prod" {
+		defVal("FIREBASE_APP", "ridecell")
+	}
 	if instance.Spec.Environment == "dev" || instance.Spec.Environment == "qa" {
 		// Enable DEBUG automatically for dev/qa.
 		val := true


### PR DESCRIPTION
This is causing bleed-through between instances which is very bad. If a prod instance reconciles and then a non-prod one follows it, it gets the prod firebase app.