### PR TITLE
Change pod disruption budget if replicas is 1

### DIFF
--- a/pkg/controller/summon/components/disruptionbudget_test.go
+++ b/pkg/controller/summon/components/disruptionbudget_test.go
@@ -33,12 +33,129 @@ import (
 var _ = Describe("servicemonitor Component", func() {
 	var comp components.Component
 
-	It("creates a pod disruption budget", func() {
+	BeforeEach(func() {
+		intp := func(i int32) *int32 { return &i }
+		replicas := &instance.Spec.Replicas
+
+		replicas.Web = intp(1)
+		replicas.Static = intp(1)
+		replicas.Daphne = intp(1)
+		replicas.ChannelWorker = intp(1)
+		replicas.Celeryd = intp(1)
+	})
+
+	It("creates a non zero web pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("web/podDisruptionBudget.yml.tpl")
+		instance.Spec.Replicas.Web = intp(2)
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-web", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("10%"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a web pod disruption budget", func() {
 		comp = summoncomponents.NewPodDisruptionBudget("web/podDisruptionBudget.yml.tpl")
 		Expect(comp).To(ReconcileContext(ctx))
 
-		disruptionBuget := &policyv1beta1.PodDisruptionBudget{}
-		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-web", Namespace: instance.Namespace}, disruptionBuget)
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-web", Namespace: instance.Namespace}, disruptionBudget)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("0"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a static pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("static/podDisruptionBudget.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-static", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("0"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a non zero static pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("static/podDisruptionBudget.yml.tpl")
+		instance.Spec.Replicas.Static = intp(2)
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-static", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("10%"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a daphne pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("daphne/podDisruptionBudget.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-daphne", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("0"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a non zero daphne pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("daphne/podDisruptionBudget.yml.tpl")
+		instance.Spec.Replicas.Daphne = intp(2)
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-daphne", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("10%"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a channelworker pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("channelworker/podDisruptionBudget.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-channelworker", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("0"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a non zero channelworker pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("channelworker/podDisruptionBudget.yml.tpl")
+		instance.Spec.Replicas.ChannelWorker = intp(2)
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-channelworker", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("10%"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a celeryd pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("celeryd/podDisruptionBudget.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-celeryd", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("0"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
+	})
+
+	It("creates a non zero celeryd pod disruption budget", func() {
+		comp = summoncomponents.NewPodDisruptionBudget("celeryd/podDisruptionBudget.yml.tpl")
+		instance.Spec.Replicas.Celeryd = intp(2)
+		Expect(comp).To(ReconcileContext(ctx))
+
+		disruptionBudget := &policyv1beta1.PodDisruptionBudget{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-celeryd", Namespace: instance.Namespace}, disruptionBudget)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disruptionBudget.Spec.MaxUnavailable.String()).To(Equal("10%"))
+		Expect(disruptionBudget.Spec.MaxUnavailable.IntValue()).To(Equal(0))
 	})
 })

--- a/pkg/controller/summon/templates/celeryd/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/celeryd/podDisruptionBudget.yml.tpl
@@ -1,3 +1,4 @@
 {{ define "componentName" }}celeryd{{ end }}
 {{ define "componentType" }}worker{{ end }}
+{{ define "maxUnavailable" }}{{ if (gt (int .Instance.Spec.Replicas.Celeryd) 1) }}10%{{ else }}0{{ end }}{{ end }}
 {{ template "podDisruptionBudget" . }}

--- a/pkg/controller/summon/templates/channelworker/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/channelworker/podDisruptionBudget.yml.tpl
@@ -1,3 +1,4 @@
 {{ define "componentName" }}channelworker{{ end }}
 {{ define "componentType" }}worker{{ end }}
+{{ define "maxUnavailable" }}{{ if (gt (int .Instance.Spec.Replicas.ChannelWorker) 1) }}10%{{ else }}0{{ end }}{{ end }}
 {{ template "podDisruptionBudget" . }}

--- a/pkg/controller/summon/templates/daphne/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/daphne/podDisruptionBudget.yml.tpl
@@ -1,3 +1,4 @@
 {{ define "componentName" }}daphne{{ end }}
 {{ define "componentType" }}web{{ end }}
+{{ define "maxUnavailable" }}{{ if (gt (int .Instance.Spec.Replicas.Daphne) 1) }}10%{{ else }}0{{ end }}{{ end }}
 {{ template "podDisruptionBudget" . }}

--- a/pkg/controller/summon/templates/helpers/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/podDisruptionBudget.yml.tpl
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Instance.Name }}
     app.kubernetes.io/managed-by: summon-operator
 spec:
-  maxUnavailable: 10%
+  maxUnavailable: {{ block "maxUnavailable" . }}{{ end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Instance.Name }}-{{ block "componentName" . }}{{ end }}

--- a/pkg/controller/summon/templates/static/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/static/podDisruptionBudget.yml.tpl
@@ -1,3 +1,4 @@
 {{ define "componentName" }}static{{ end }}
 {{ define "componentType" }}web{{ end }}
+{{ define "maxUnavailable" }}{{ if (gt (int .Instance.Spec.Replicas.Static) 1) }}10%{{ else }}0{{ end }}{{ end }}
 {{ template "podDisruptionBudget" . }}

--- a/pkg/controller/summon/templates/web/podDisruptionBudget.yml.tpl
+++ b/pkg/controller/summon/templates/web/podDisruptionBudget.yml.tpl
@@ -1,3 +1,4 @@
 {{ define "componentName" }}web{{ end }}
 {{ define "componentType" }}web{{ end }}
+{{ define "maxUnavailable" }}{{ if (gt (int .Instance.Spec.Replicas.Web) 1) }}10%{{ else }}0{{ end }}{{ end }}
 {{ template "podDisruptionBudget" . }}


### PR DESCRIPTION
A disruption budget of  "maxUnavailable: 1" with "replicas: 1" will prevent pods from being evicted.