### PR TITLE
Force the deployment controller to kill the existing pod before starting the new one

### DIFF
--- a/pkg/controller/summon/templates/redis/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/redis/deployment.yml.tpl
@@ -12,6 +12,10 @@ metadata:
     metrics-enabled: "false"
 spec:
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Instance.Name }}-redis


### PR DESCRIPTION
Basically a janky statefulset, but it will unblock Avdhoot I think.