### PR TITLE
Properly label metrics service

### DIFF
--- a/pkg/controller/summon/templates/helpers/service.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/service.yml.tpl
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/component: {{ block "componentType" . }}{{ end }}
     app.kubernetes.io/part-of: {{ .Instance.Name }}
     app.kubernetes.io/managed-by: summon-operator
+    {{ block "extraLabels" . }}{{ end -}}
   annotations:
 {{ block "extraAnnotations" . }}{{ end -}}
 spec:

--- a/pkg/controller/summon/templates/metrics/service.yml.tpl
+++ b/pkg/controller/summon/templates/metrics/service.yml.tpl
@@ -1,5 +1,6 @@
 {{ define "componentName" }}metrics{{ end }}
 {{ define "componentType" }}metrics{{ end }}
+{{ define "extraLabels" }}metrics-enabled: "true"{{ end }}
 {{ define "servicePorts" }}[{protocol: TCP, port: 9000}]{{ end }}
 {{ define "selectors" }}{app.kubernetes.io/part-of: {{ .Instance.Name }}, metrics-enabled: "true"}{{ end }}
 {{ template "service" . }}


### PR DESCRIPTION
Label needs to be passed down to endpoints for them to be selected by the ServiceMonitor