### PR TITLE
Rearrange things so the prod default for FIREBASE_APP is set before the global defaults are merged in

### DIFF
--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -216,4 +216,14 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.Spec.Config["FIREBASE_APP"].String).To(PointTo(Equal("instant-stage")))
 	})
+
+	It("does not set a default FIREBASE_APP if one is already present", func() {
+		instance.Namespace = "summon-qa"
+		f := "foo"
+		instance.Spec.Config = map[string]summonv1beta1.ConfigValue{
+			"FIREBASE_APP": summonv1beta1.ConfigValue{String: &f},
+		}
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.Spec.Config["FIREBASE_APP"].String).To(PointTo(Equal("foo")))
+	})
 })

--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -204,4 +204,16 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 			Expect(instance.Spec.Config["CACHE_URL"].String).To(PointTo(Equal("redis://awsredis/1")))
 		})
 	})
+
+	It("sets a default prod FIREBASE_APP", func() {
+		instance.Namespace = "summon-prod"
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.Spec.Config["FIREBASE_APP"].String).To(PointTo(Equal("ridecell")))
+	})
+
+	It("sets a default qa FIREBASE_APP", func() {
+		instance.Namespace = "summon-qa"
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.Spec.Config["FIREBASE_APP"].String).To(PointTo(Equal("instant-stage")))
+	})
 })


### PR DESCRIPTION
Otherwise the global default is already there and defVal won't overwrite it because it only sets things if they don't exist to allow for end-user overrides.