### PR TITLE
set backup retention to 7 days

### DIFF
--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -218,7 +218,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	}
 	
 	// If DB does not have a backup retention period of 7 days, set it to 7 days now
-	if database.BackupRetentionPeriod != aws.Int64(7) {
+	if aws.Int64Value(database.BackupRetentionPeriod) != 7 {
 		needsUpdate = true
 		databaseModifyInput.BackupRetentionPeriod = aws.Int64(7)
 	}

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -214,7 +214,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	// This does exclude instance size for now
 	databaseModifyInput := &rds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: database.DBInstanceIdentifier,
-		ApplyImmediately:     aws.Bool(true)
+		ApplyImmediately:     aws.Bool(true),
 	}
 	
 	// If DB does not have a backup retention period of 7 days, set it to 7 days now
@@ -223,7 +223,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 		databaseModifyInput := &rds.ModifyDBInstanceInput{
 			DBInstanceIdentifier: database.DBInstanceIdentifier,
 			BackupRetentionPeriod: aws.Int64(7),
-			ApplyImmediately:     aws.Bool(true)
+			ApplyImmediately:     aws.Bool(true),
 		}
 	}
 

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -145,6 +145,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 			StorageType:                aws.String("gp2"),
 			AllocatedStorage:           aws.Int64(instance.Spec.AllocatedStorage),
 			DBInstanceClass:            aws.String(instance.Spec.InstanceClass),
+			BackupRetentionPeriod:      aws.Int64(7)
 			PreferredMaintenanceWindow: aws.String(instance.Spec.MaintenanceWindow),
 			Engine:                     aws.String(instance.Spec.Engine),
 			EngineVersion:              aws.String(instance.Spec.EngineVersion),
@@ -215,6 +216,8 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 		DBInstanceIdentifier: database.DBInstanceIdentifier,
 		ApplyImmediately:     aws.Bool(true),
 	}
+	
+
 	// TODO: Things could get weird if allocated storage is increased by less than 10% as aws will automatically round up to the nearest 10% increase
 	// This is pretty unlikely to happen even at larger numbers.
 	if aws.Int64Value(database.AllocatedStorage) != instance.Spec.AllocatedStorage {

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -220,11 +220,7 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 	// If DB does not have a backup retention period of 7 days, set it to 7 days now
 	if database.BackupRetentionPeriod != aws.Int64(7) {
 		needsUpdate = true
-		databaseModifyInput := &rds.ModifyDBInstanceInput{
-			DBInstanceIdentifier: database.DBInstanceIdentifier,
-			BackupRetentionPeriod: aws.Int64(7),
-			ApplyImmediately:     aws.Bool(true),
-		}
+		databaseModifyInput.BackupRetentionPeriod = aws.Int64(7)
 	}
 
 	// TODO: Things could get weird if allocated storage is increased by less than 10% as aws will automatically round up to the nearest 10% increase

--- a/pkg/controller/rds/components/rds_instance_test.go
+++ b/pkg/controller/rds/components/rds_instance_test.go
@@ -166,13 +166,13 @@ var _ = Describe("rds aws Component", func() {
 		mockRDS.dbInstanceExists = true
 		mockRDS.hasTags = true
 		mockRDS.dbStatus = "pending-reboot"
+		mockRDS.has7dayBackup = true
 
 		dbMock.ExpectQuery("SELECT 1;").WillReturnRows(sqlmock.NewRows([]string{"test"}).AddRow(1)).RowsWillBeClosed()
 
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
-		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for existing db before, it will now.
-		Expect(mockRDS.modifiedDB).To(BeTrue())
+		Expect(mockRDS.modifiedDB).To(BeFalse())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeFalse())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())
@@ -210,10 +210,10 @@ var _ = Describe("rds aws Component", func() {
 	It("has a database with no tags", func() {
 		mockRDS.dbInstanceExists = true
 		mockRDS.dbStatus = "available"
+		mockRDS.has7dayBackup = true
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
-		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for db before, it will now.
-		Expect(mockRDS.modifiedDB).To(BeTrue())
+		Expect(mockRDS.modifiedDB).To(BeFalse())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeTrue())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())

--- a/pkg/controller/rds/components/rds_instance_test.go
+++ b/pkg/controller/rds/components/rds_instance_test.go
@@ -52,6 +52,7 @@ type mockRDSDBClient struct {
 	modifiedDB        bool
 	deletedDBInstance bool
 	addedTags         bool
+	has7dayBackup     bool
 	dbStatus          string
 }
 
@@ -137,6 +138,23 @@ var _ = Describe("rds aws Component", func() {
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
 		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for existing db before, it will now.
 		Expect(mockRDS.modifiedDB).To(BeTrue())
+		Expect(mockRDS.createdDB).To(BeFalse())
+		Expect(mockRDS.deletedDBInstance).To(BeFalse())
+		Expect(mockRDS.addedTags).To(BeFalse())
+		Expect(instance.Status.Status).To(Equal(dbv1beta1.StatusReady))
+	})
+
+	It("has a database in available state with backup retention of 7 days", func() {
+		instance.Status.Status = dbv1beta1.StatusReady
+		mockRDS.dbInstanceExists = true
+		mockRDS.hasTags = true
+		mockRDS.dbStatus = "available"
+		mockRDS.has7dayBackup = true
+		dbMock.ExpectQuery("SELECT 1;").WillReturnRows(sqlmock.NewRows([]string{"test"}).AddRow(1)).RowsWillBeClosed()
+
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
+		Expect(mockRDS.modifiedDB).To(BeFalse())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeFalse())
@@ -233,6 +251,9 @@ func (m *mockRDSDBClient) DescribeDBInstances(input *rds.DescribeDBInstancesInpu
 				MasterUsername:   aws.String("test-user"),
 				DBInstanceStatus: aws.String(m.dbStatus),
 			},
+		}
+		if m.has7dayBackup {
+			dbInstances[0].BackupRetentionPeriod = aws.Int64(7)
 		}
 		return &rds.DescribeDBInstancesOutput{DBInstances: dbInstances}, nil
 	}

--- a/pkg/controller/rds/components/rds_instance_test.go
+++ b/pkg/controller/rds/components/rds_instance_test.go
@@ -135,7 +135,8 @@ var _ = Describe("rds aws Component", func() {
 		Expect(comp).To(ReconcileContext(ctx))
 
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
-		Expect(mockRDS.modifiedDB).To(BeFalse())
+		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for existing db before, it will now.
+		Expect(mockRDS.modifiedDB).To(BeTrue())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeFalse())
@@ -152,7 +153,8 @@ var _ = Describe("rds aws Component", func() {
 
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
-		Expect(mockRDS.modifiedDB).To(BeFalse())
+		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for existing db before, it will now.
+		Expect(mockRDS.modifiedDB).To(BeTrue())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeFalse())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())
@@ -190,10 +192,10 @@ var _ = Describe("rds aws Component", func() {
 	It("has a database with no tags", func() {
 		mockRDS.dbInstanceExists = true
 		mockRDS.dbStatus = "available"
-
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.ObjectMeta.Finalizers[0]).To(Equal("rdsinstance.database.finalizer"))
-		Expect(mockRDS.modifiedDB).To(BeFalse())
+		// PR #218 - Expect modified to be true because if backupRetentionPeriod wasn't set for db before, it will now.
+		Expect(mockRDS.modifiedDB).To(BeTrue())
 		Expect(mockRDS.createdDB).To(BeFalse())
 		Expect(mockRDS.addedTags).To(BeTrue())
 		Expect(mockRDS.deletedDBInstance).To(BeFalse())
@@ -245,6 +247,7 @@ func (m *mockRDSDBClient) CreateDBInstance(input *rds.CreateDBInstanceInput) (*r
 		},
 		MasterUsername:   aws.String("test-user"),
 		DBInstanceStatus: aws.String("creating"),
+		BackupRetentionPeriod: aws.Int64(7),
 	}
 	m.createdDB = true
 	m.hasTags = true

--- a/pkg/controller/rds/components/rds_instance_test.go
+++ b/pkg/controller/rds/components/rds_instance_test.go
@@ -125,7 +125,7 @@ var _ = Describe("rds aws Component", func() {
 		Expect(instance.Status.Status).To(Equal(dbv1beta1.StatusCreating))
 	})
 
-	It("has a database in available state", func() {
+	It("has a database in available state without backup retention of 7 days", func() {
 		instance.Status.Status = dbv1beta1.StatusReady
 		mockRDS.dbInstanceExists = true
 		mockRDS.hasTags = true


### PR DESCRIPTION
turns out default was 1 day if using RDS API to create databases