### PR TITLE
Fix djangouser creation

### DIFF
--- a/pkg/apis/summon/v1beta1/djangouser_types.go
+++ b/pkg/apis/summon/v1beta1/djangouser_types.go
@@ -24,15 +24,16 @@ import (
 
 // DjangoUserSpec defines the desired state of DjangoUser
 type DjangoUserSpec struct {
-	Email      string                       `json:"email"`
-	Database   dbv1beta1.PostgresConnection `json:"database"`
-	FirstName  string                       `json:"firstName,omitempty"`
-	LastName   string                       `json:"lastName,omitempty"`
-	Active     bool                         `json:"active"`
-	Manager    bool                         `json:"manager"`
-	Dispatcher bool                         `json:"dispatcher"`
-	Staff      bool                         `json:"staff"`
-	Superuser  bool                         `json:"superuser"`
+	Email         string                       `json:"email"`
+	Database      dbv1beta1.PostgresConnection `json:"database"`
+	FirstName     string                       `json:"firstName,omitempty"`
+	LastName      string                       `json:"lastName,omitempty"`
+	Active        bool                         `json:"active"`
+	Manager       bool                         `json:"manager"`
+	Dispatcher    bool                         `json:"dispatcher"`
+	Staff         bool                         `json:"staff"`
+	Superuser     bool                         `json:"superuser"`
+	BusinessAdmin bool                         `json:"businessAdmin"`
 }
 
 // DjangoUserStatus defines the observed state of DjangoUser

--- a/pkg/controller/djangouser/components/database.go
+++ b/pkg/controller/djangouser/components/database.go
@@ -118,7 +118,7 @@ INSERT INTO common_staff (user_profile_id, is_active, manager, dispatcher, busin
     is_active=EXCLUDED.is_active,
     manager=EXCLUDED.manager,
     dispatcher=EXCLUDED.dispatcher,
-		business_admin=EXCLUDED.business_admin;
+    business_admin=EXCLUDED.business_admin;
 `
 
 	// Create the common_staff.

--- a/pkg/controller/djangouser/components/database.go
+++ b/pkg/controller/djangouser/components/database.go
@@ -112,16 +112,17 @@ INSERT INTO common_userprofile (user_id, is_jumio_verified, created_at, updated_
 
 	// Medium ass SQL.
 	query = `
-INSERT INTO common_staff (user_profile_id, is_active, manager, dispatcher)
-  VALUES ($1, $2, $3, $4)
+INSERT INTO common_staff (user_profile_id, is_active, manager, dispatcher, business_admin)
+  VALUES ($1, $2, $3, $4, $5)
   ON CONFLICT (user_profile_id) DO UPDATE SET
     is_active=EXCLUDED.is_active,
     manager=EXCLUDED.manager,
-    dispatcher=EXCLUDED.dispatcher;
+    dispatcher=EXCLUDED.dispatcher,
+		business_admin=EXCLUDED.business_admin;
 `
 
 	// Create the common_staff.
-	_, err = db.Exec(query, profileId, instance.Spec.Active, instance.Spec.Manager, instance.Spec.Dispatcher)
+	_, err = db.Exec(query, profileId, instance.Spec.Active, instance.Spec.Manager, instance.Spec.Dispatcher, instance.Spec.BusinessAdmin)
 	if err != nil {
 		return components.Result{}, errors.Wrap(err, "database: Error running common_staff query")
 	}

--- a/pkg/controller/djangouser/components/database_test.go
+++ b/pkg/controller/djangouser/components/database_test.go
@@ -134,7 +134,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 		rows2 := sqlmock.NewRows([]string{"id"}).AddRow(1)
 		dbMock.ExpectQuery("INSERT INTO auth_user").WithArgs("foo@example.com", passwordMatching{password: "djangopass"}, "", "", false, false, false).WillReturnRows(rows)
 		dbMock.ExpectQuery("INSERT INTO common_userprofile").WithArgs(1).WillReturnRows(rows2)
-		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, false, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
+		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, false, false, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))
@@ -163,7 +163,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 		rows2 := sqlmock.NewRows([]string{"id"}).AddRow(1)
 		dbMock.ExpectQuery("INSERT INTO auth_user").WithArgs("foo@example.com", passwordMatching{password: "djangopass"}, "", "", true, true, false).WillReturnRows(rows)
 		dbMock.ExpectQuery("INSERT INTO common_userprofile").WithArgs(1).WillReturnRows(rows2)
-		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, true, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
+		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, true, false, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))
@@ -192,7 +192,7 @@ var _ = Describe("DjangoUser Database Component", func() {
 		rows2 := sqlmock.NewRows([]string{"id"}).AddRow(1)
 		dbMock.ExpectQuery("INSERT INTO auth_user").WithArgs("foo@example.com", passwordMatching{password: "djangopass"}, "Alan", "Smithee", false, false, false).WillReturnRows(rows)
 		dbMock.ExpectQuery("INSERT INTO common_userprofile").WithArgs(1).WillReturnRows(rows2)
-		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, false, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
+		dbMock.ExpectExec("INSERT INTO common_staff").WithArgs(1, false, false, false, false).WillReturnResult(sqlmock.NewResult(0, 1))
 
 		comp := djangousercomponents.NewDatabase()
 		Expect(comp).To(ReconcileContext(ctx))

--- a/pkg/controller/djangouser/controller_test.go
+++ b/pkg/controller/djangouser/controller_test.go
@@ -83,7 +83,7 @@ CREATE TABLE common_staff (
     dispatcher boolean NOT NULL,
     manager boolean NOT NULL,
     is_active boolean NOT NULL,
-    business_admin NOT NULL,
+    business_admin boolean NOT NULL,
     user_profile_id integer NOT NULL UNIQUE REFERENCES common_userprofile (id),
     created_at timestamp with time zone,
     updated_at timestamp with time zone

--- a/pkg/controller/djangouser/controller_test.go
+++ b/pkg/controller/djangouser/controller_test.go
@@ -83,6 +83,7 @@ CREATE TABLE common_staff (
     dispatcher boolean NOT NULL,
     manager boolean NOT NULL,
     is_active boolean NOT NULL,
+		business_admin NOT NULL,
     user_profile_id integer NOT NULL UNIQUE REFERENCES common_userprofile (id),
     created_at timestamp with time zone,
     updated_at timestamp with time zone

--- a/pkg/controller/djangouser/controller_test.go
+++ b/pkg/controller/djangouser/controller_test.go
@@ -83,7 +83,7 @@ CREATE TABLE common_staff (
     dispatcher boolean NOT NULL,
     manager boolean NOT NULL,
     is_active boolean NOT NULL,
-		business_admin NOT NULL,
+    business_admin NOT NULL,
     user_profile_id integer NOT NULL UNIQUE REFERENCES common_userprofile (id),
     created_at timestamp with time zone,
     updated_at timestamp with time zone


### PR DESCRIPTION
A new NOT NULL column was added to the common_staff table causing new django user creations to fail. 
https://github.com/Ridecell/summon-platform/pull/10486