### PR TITLE
✨Bump postgres certs image version

### DIFF
--- a/pkg/controller/shared_components/postgres/templates/postgres-exporter.yml.tpl
+++ b/pkg/controller/shared_components/postgres/templates/postgres-exporter.yml.tpl
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: copy-certs
-        image: us.gcr.io/ridecell-1/postgres-exporter-certs:1
+        image: us.gcr.io/ridecell-1/postgres-exporter-certs:2
         command:
         - sh
         - -c


### PR DESCRIPTION
This pulls in a newly-rebuilt image with the new 2019 CA certs for RDS.