### PR TITLE
Make all bools optional in djangouser template to fix validation error

### DIFF
--- a/pkg/apis/summon/v1beta1/djangouser_types.go
+++ b/pkg/apis/summon/v1beta1/djangouser_types.go
@@ -28,12 +28,12 @@ type DjangoUserSpec struct {
 	Database      dbv1beta1.PostgresConnection `json:"database"`
 	FirstName     string                       `json:"firstName,omitempty"`
 	LastName      string                       `json:"lastName,omitempty"`
-	Active        bool                         `json:"active"`
-	Manager       bool                         `json:"manager"`
-	Dispatcher    bool                         `json:"dispatcher"`
-	Staff         bool                         `json:"staff"`
-	Superuser     bool                         `json:"superuser"`
-	BusinessAdmin bool                         `json:"businessAdmin"`
+	Active        bool                         `json:"active,omitempty"`
+	Manager       bool                         `json:"manager,omitempty"`
+	Dispatcher    bool                         `json:"dispatcher,omitempty"`
+	Staff         bool                         `json:"staff,omitempty"`
+	Superuser     bool                         `json:"superuser,omitempty"`
+	BusinessAdmin bool                         `json:"businessAdmin,omitempty"`
 }
 
 // DjangoUserStatus defines the observed state of DjangoUser


### PR DESCRIPTION
Validation changes in newer kubernetes versions means we have to explicity mark these fields as optional or update the superuser template with all of the required variables.

The superuser summon component tests are passing incorrectly as it is still running an older version of kubernetes. The current configuration was observed to fail on k8s v1.17.