### PR TITLE
Point eu-uat and in-uat at their respective prod data pipeline queues.

### DIFF
--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -114,9 +114,9 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		case "uat":
 			switch instance.Spec.AwsRegion {
 			case "eu-central-1":
-				instance.Spec.SQSQueue = "eu-uat-data-pipeline"
+				instance.Spec.SQSQueue = "eu-prod-data-pipeline"
 			case "ap-south-1":
-				instance.Spec.SQSQueue = "in-uat-data-pipeline"
+				instance.Spec.SQSQueue = "in-prod-data-pipeline"
 			default:
 				instance.Spec.SQSQueue = "us-uat-data-pipeline"
 			}


### PR DESCRIPTION
Once those environments exist, we can revert this.