### PR TITLE
CORE-1813: Fixing python2 to python3 migration caching issues

### DIFF
--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -178,11 +178,17 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	defVal("WEB_URL", "https://%s", webURL)
 
 	if instance.Spec.MigrationOverrides.RedisHostname != "" {
-		defVal("ASGI_URL", "redis://%s/1", instance.Spec.MigrationOverrides.RedisHostname)
+		defVal("ASGI_URL", "redis://%s/0", instance.Spec.MigrationOverrides.RedisHostname)
 		defVal("CACHE_URL", "redis://%s/1", instance.Spec.MigrationOverrides.RedisHostname)
+		// These config's should be removed when all tenants are migrated to python3
+		defVal("ASGI_URL_V2", "redis://%s/2", instance.Spec.MigrationOverrides.RedisHostname)
+		defVal("CACHE_URL_V2", "redis://%s/3", instance.Spec.MigrationOverrides.RedisHostname)
 	} else {
 		defVal("ASGI_URL", "redis://%s-redis/0", instance.Name)
 		defVal("CACHE_URL", "redis://%s-redis/1", instance.Name)
+		// These config's should be removed when all tenants are migrated to python3
+		defVal("ASGI_URL_V2", "redis://%s-redis/2", instance.Name)
+		defVal("CACHE_URL_V2", "redis://%s-redis/3", instance.Name)
 	}
 
 	defVal("FIREBASE_ROOT_NODE", "%s", instance.Name)

--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -202,8 +202,10 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 
 		It("sets the redis ", func() {
 			Expect(comp).To(ReconcileContext(ctx))
-			Expect(instance.Spec.Config["ASGI_URL"].String).To(PointTo(Equal("redis://awsredis/1")))
+			Expect(instance.Spec.Config["ASGI_URL"].String).To(PointTo(Equal("redis://awsredis/0")))
 			Expect(instance.Spec.Config["CACHE_URL"].String).To(PointTo(Equal("redis://awsredis/1")))
+			Expect(instance.Spec.Config["ASGI_URL_V2"].String).To(PointTo(Equal("redis://awsredis/2")))
+			Expect(instance.Spec.Config["CACHE_URL_V3"].String).To(PointTo(Equal("redis://awsredis/3")))
 		})
 	})
 


### PR DESCRIPTION
* Added new config's ASGI_URL_V2 and CACHE_URL_V2
* Updated test