### PR TITLE
✨ Add support for running the core_1540_pre_migrate step before migrations

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -225,6 +225,10 @@ type SummonPlatformSpec struct {
 	// Settings for comp-dispatch.
 	// +optional
 	Dispatch CompDispatchSpec `json:"dispatch,omitempty"`
+	// Feature flag to disable the CORE-1540 fixup in case it goes AWOL.
+	// To be removed when support for the 1540 fixup is removed in summon.
+	// +optional
+	NoCore1540Fixup bool `json:"noCore1540Fixup,omitempty"`
 }
 
 // NotificationStatus defines the observed state of Notifications

--- a/pkg/controller/summon/templates/migrations.yml.tpl
+++ b/pkg/controller/summon/templates/migrations.yml.tpl
@@ -34,7 +34,7 @@ spec:
         {{- if ne .Extra.presignedUrl "" }}
         - python manage.py migrate -v3 && python manage.py loadflavor {{ .Extra.presignedUrl | squote }} --silent
         {{- else }}
-        - python manage.py migrate -v3
+        - {{ if and (not .Instance.Spec.NoCore1540Fixup) (ne .Instance.Status.MigrateVersion "") }}if [ -f common/management/commands/core_1540_pre_migrate.py ]; then python manage.py core_1540_pre_migrate; fi && {{ end }}python manage.py migrate -v3
         {{- end }}
         resources:
           requests:


### PR DESCRIPTION
This is needed for the PCR 2 rollout.

Once PCR 2 is everywhere and we don't plan to allow deploying earlier builds, we can remove all of this.