### PR TITLE
🐛 Changing which GMaps key is used for comp-dispatch.

### DIFF
--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -232,7 +232,7 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	}
 	dispatchSecretsData["Debug"] = debug
 	dispatchSecretsData["DatabaseURL"] = strings.Replace(appSecretsData["DATABASE_URL"].(string), "postgis://", "postgres://", 1)
-	dispatchSecretsData["GoogleApiKey"] = appSecretsData["GMAPS_CLIENT_KEY"]
+	dispatchSecretsData["GoogleApiKey"] = appSecretsData["GOOGLE_MAPS_BACKEND_API_KEY"]
 
 	// Serialize the app secrets YAML and put it in a secret.
 	yamlData, err := yaml.Marshal(appSecretsData)

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -316,7 +316,7 @@ var _ = Describe("app_secrets Component", func() {
 	})
 
 	It("creates a comp-dispatch secret", func() {
-		inSecret.Data["GMAPS_CLIENT_KEY"] = []byte("asdf1234")
+		inSecret.Data["GOOGLE_MAPS_BACKEND_API_KEY"] = []byte("asdf1234")
 		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey, rabbitmqPassword)
 		Expect(comp).To(ReconcileContext(ctx))
 
@@ -337,7 +337,7 @@ var _ = Describe("app_secrets Component", func() {
 		instance.Spec.Config = map[string]summonv1beta1.ConfigValue{
 			"DEBUG": summonv1beta1.ConfigValue{Bool: &v},
 		}
-		inSecret.Data["GMAPS_CLIENT_KEY"] = []byte("asdf1234")
+		inSecret.Data["GOOGLE_MAPS_BACKEND_API_KEY"] = []byte("asdf1234")
 		ctx.Client = fake.NewFakeClient(inSecret, postgresSecret, fernetKeys, secretKey, accessKey, rabbitmqPassword)
 		Expect(comp).To(ReconcileContext(ctx))
 


### PR DESCRIPTION

As requested by the Ridesharing team.