### PR TITLE
✨ Globally disable NewRelic browser as we don't use it.

### DIFF
--- a/pkg/controller/summon/templates/newrelic.yml.tpl
+++ b/pkg/controller/summon/templates/newrelic.yml.tpl
@@ -10,4 +10,5 @@ stringData:
     app_name = {{ .Instance.Name }}-summon-platform
     error_collector.ignore_errors = celery.exceptions:Retry
     error_collector.ignore_status_codes = 100-102 200-208 226 300-308 400-499
+    browser_monitoring.auto_instrument = false
   NEW_RELIC_LICENSE_KEY: {{ env "NEW_RELIC_LICENSE_KEY" }}


### PR DESCRIPTION
This should help reduce our NR DU consumption, I hope.

Docs at https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration#browser-auto