### PR TITLE
🐛 comp-trip-share is using /trip_share as the URL path on its side

### DIFF
--- a/pkg/controller/summon/templates/tripShare/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/tripShare/ingress.yml.tpl
@@ -1,4 +1,4 @@
 {{ define "componentName" }}tripshare{{ end }}
 {{ define "componentType" }}web{{ end }}
-{{ define "ingressPath" }}/tripshare{{ end }}
+{{ define "ingressPath" }}/trip_share{{ end }}
 {{ template "ingress" . }}


### PR DESCRIPTION
Hopefully we can revert this in the future since underscores in user-facing URL paths is usually discouraged.