### PR TITLE
🐛 Add a quick hack for DISPATCH_BASE_URL setting to only exist if the…

### DIFF
--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -242,7 +242,7 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 		instance.Spec.Dispatch.Version = "foo"
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.Spec.Config["DISPATCH_ENABLED"].Bool).To(PointTo(BeTrue()))
-		Expect(instance.Spec.Config["DISPATCH_BASE_URL"].String).To(Equal("http://foo-dev-dispatch:8000/"))
+		Expect(instance.Spec.Config["DISPATCH_BASE_URL"].String).To(PointTo(Equal("http://foo-dev-dispatch:8000/")))
 	})
 
 	It("does not DISPATCH_ENABLED if the dispatch component is not enabled", func() {

--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -237,4 +237,18 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 			Expect(instance.Spec.Replicas.CeleryBeat).To(PointTo(BeEquivalentTo(1)))
 		})
 	})
+
+	It("sets DISPATCH_ENABLED if the dispatch component is enabled", func() {
+		instance.Spec.Dispatch.Version = "foo"
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.Spec.Config["DISPATCH_ENABLED"].Bool).To(PointTo(BeTrue()))
+		Expect(instance.Spec.Config["DISPATCH_BASE_URL"].String).To(Equal("http://foo-dev-dispatch:8000/"))
+	})
+
+	It("does not DISPATCH_ENABLED if the dispatch component is not enabled", func() {
+		Expect(comp).To(ReconcileContext(ctx))
+		Expect(instance.Spec.Config["DISPATCH_ENABLED"].Bool).To(PointTo(BeFalse()))
+		// NOTE: This assertion will be removed when #269 is put back so DISPATCH_BASE_URL is always set.
+		Expect(instance.Spec.Config).ToNot(ContainElement("DISPATCH_BASE_URL"))
+	})
 })


### PR DESCRIPTION
… component is on.

This was a misunderstanding with the comp-dispatch team. I've added a DISPATCH_ENABLED boolean flag for a better solution for the future, but for now make it conditional so we can silence errors in PCR-4/5 (i.e. until a fixed Summon is available).