### PR TITLE
✨ Allow specifying redis RAM in MB instead of GB.

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -68,7 +68,7 @@ type CelerySpec struct {
 
 // RedisSpec defines resource configuration for redis deployment.
 type RedisSpec struct {
-	// Setting for tuning redis memory request/limit in GB.
+	// Setting for tuning redis memory request/limit in MB (or GB if over 10).
 	// +optional
 	RAM int `json:"ram,omitempty"`
 }

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -70,13 +70,13 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	}
 
 	// If the persistentVolumeClaim for redis changes this integer should as well.
-	if instance.Spec.Redis.RAM > 10 {
+	if instance.Spec.Redis.RAM > 10*1024 {
 		return components.Result{}, errors.New("redis memory limit cannot surpass available disk space")
 	}
 
 	// Set redis defaults
 	if instance.Spec.Redis.RAM == 0 {
-		instance.Spec.Redis.RAM = 1
+		instance.Spec.Redis.RAM = 200
 	}
 
 	// Helper method to set a string value if not already set.

--- a/pkg/controller/summon/components/redis_deployment_test.go
+++ b/pkg/controller/summon/components/redis_deployment_test.go
@@ -22,7 +22,9 @@ import (
 	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
@@ -40,5 +42,29 @@ var _ = Describe("redis_deployment Component", func() {
 		deployment := &appsv1.Deployment{}
 		err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-redis", Namespace: "summon-dev"}, deployment)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("sets the RAM when given in GB", func() {
+		instance.Status.Status = summonv1beta1.StatusDeploying
+		instance.Spec.Redis.RAM = 2
+		comp := summoncomponents.NewRedisDeployment("redis/deployment.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		deployment := &appsv1.Deployment{}
+		err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-redis", Namespace: "summon-dev"}, deployment)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory()).To(PointTo(Equal(resource.MustParse("2G"))))
+	})
+
+	It("sets the RAM when given in MB", func() {
+		instance.Status.Status = summonv1beta1.StatusDeploying
+		instance.Spec.Redis.RAM = 300
+		comp := summoncomponents.NewRedisDeployment("redis/deployment.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+
+		deployment := &appsv1.Deployment{}
+		err := ctx.Get(context.TODO(), types.NamespacedName{Name: "foo-dev-redis", Namespace: "summon-dev"}, deployment)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory()).To(PointTo(Equal(resource.MustParse("300M"))))
 	})
 })

--- a/pkg/controller/summon/templates/redis/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/redis/deployment.yml.tpl
@@ -41,10 +41,10 @@ spec:
           mountPath: /data
         resources:
           requests:
-            memory: {{ .Instance.Spec.Redis.RAM }}{{ if lt .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
+            memory: {{ .Instance.Spec.Redis.RAM }}{{ if le .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
             cpu: 25m
           limits:
-            memory: {{ .Instance.Spec.Redis.RAM }}{{ if lt .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
+            memory: {{ .Instance.Spec.Redis.RAM }}{{ if le .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
         readinessProbe:
           exec:
             command:

--- a/pkg/controller/summon/templates/redis/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/redis/deployment.yml.tpl
@@ -41,10 +41,10 @@ spec:
           mountPath: /data
         resources:
           requests:
-            memory: {{ .Instance.Spec.Redis.RAM }}G
+            memory: {{ .Instance.Spec.Redis.RAM }}{{ if lt .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
             cpu: 25m
           limits:
-            memory: {{ .Instance.Spec.Redis.RAM }}G
+            memory: {{ .Instance.Spec.Redis.RAM }}{{ if lt .Instance.Spec.Redis.RAM 10 }}G{{ else }}M{{ end }}
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Once all instances are updated to use MB, we can remove the GB units support. We will also have to set overrides on a bunch of instances before this goes up.