### PR TITLE
✨ Substantially increase the RAM limit for comp-dispatch

### DIFF
--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -57,7 +57,7 @@ spec:
             memory: 25M
             cpu: 5m
           limits:
-            memory: 40M
+            memory: 160M
         env:
         - name: SUMMON_COMPONENT
           valueFrom:


### PR DESCRIPTION
The ridesharing team is throwing more load at it, and it is OOMing. Some fixes are in progress on the comp side but also bump the limit until we can find a new better value.