### PR TITLE
DEVOPS-2253 Comp dispatch change

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -158,6 +158,10 @@ type MetricsSpec struct {
 type CompDispatchSpec struct {
 	// Comp-dispatch image version to deploy.
 	Version string `json:"version"`
+	// Compute Resources required by this container.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+	// +optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"`
 }
 
 // CompBusinessPortalSpec defines settings for comp-business-portal.

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -82,7 +82,7 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	}
 
 	// If no resource requests provided, set default requests/limits
-	if instance.Spec.Dispatch.Version != "" && *instance.Spec.Dispatch.Resources == nil {
+	if instance.Spec.Dispatch.Version != "" && instance.Spec.Dispatch.Resources.Size() == 0 {
 		instance.Spec.Dispatch.Resources = corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("160M"),

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -27,6 +27,7 @@ import (
 
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
 	"github.com/Ridecell/ridecell-operator/pkg/components"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const defaultFernetKeysLifespan = "8760h"
@@ -77,6 +78,19 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	// Set redis defaults
 	if instance.Spec.Redis.RAM == 0 {
 		instance.Spec.Redis.RAM = 200
+	}
+
+	// If no resource requests provided, set default requests/limits
+	if instance.Spec.Dispatch.Version != "" && instance.Spec.Dispatch.Resources == nil {
+		instance.Spec.Dispatch.Resources = corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: "160M",
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: "25M",
+				corev1.ResourceCPU:    "5m",
+			},
+		}
 	}
 
 	// Helper method to set a string value if not already set.
@@ -245,7 +259,7 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		defBoolVal("DEBUG", true)
 		gatewayEnv = "master"
 	}
-	
+
 	if instance.Spec.Environment != "prod" {
 		defBoolVal("ENABLE_JSON_LOGGING", true)
 	}

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -82,7 +82,7 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	}
 
 	// If no resource requests provided, set default requests/limits
-	if instance.Spec.Dispatch.Version != "" && instance.Spec.Dispatch.Resources == nil {
+	if instance.Spec.Dispatch.Version != "" && *instance.Spec.Dispatch.Resources == nil {
 		instance.Spec.Dispatch.Resources = corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("160M"),

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
@@ -84,11 +85,11 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 	if instance.Spec.Dispatch.Version != "" && instance.Spec.Dispatch.Resources == nil {
 		instance.Spec.Dispatch.Resources = corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: "160M",
+				corev1.ResourceMemory: resource.MustParse("160M"),
 			},
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: "25M",
-				corev1.ResourceCPU:    "5m",
+				corev1.ResourceMemory: resource.MustParse("25M"),
+				corev1.ResourceCPU:    resource.MustParse("5m"),
 			},
 		}
 	}

--- a/pkg/controller/summon/components/defaults_test.go
+++ b/pkg/controller/summon/components/defaults_test.go
@@ -249,6 +249,7 @@ var _ = Describe("SummonPlatform Defaults Component", func() {
 		Expect(comp).To(ReconcileContext(ctx))
 		Expect(instance.Spec.Config["DISPATCH_ENABLED"].Bool).To(PointTo(BeTrue()))
 		Expect(instance.Spec.Config["DISPATCH_BASE_URL"].String).To(PointTo(Equal("http://foo-dev-dispatch:8000/")))
+		Expect(instance.Spec.Dispatch.Resources).ToNot(BeNil())
 	})
 
 	It("does not DISPATCH_ENABLED if the dispatch component is not enabled", func() {

--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -52,12 +52,7 @@ spec:
         image: "us.gcr.io/ridecell-1/comp-dispatch:{{ .Instance.Spec.Dispatch.Version }}"
         ports:
         - containerPort: 8000
-        resources:
-          requests:
-            memory: 25M
-            cpu: 5m
-          limits:
-            memory: 160M
+        resources: {{ .Instance.Spec.Dispatch.Resources | toJson }}
         env:
         - name: SUMMON_COMPONENT
           valueFrom:


### PR DESCRIPTION
Make comp-dispatch resources configurable.
Instead of defining separate values for resources, we can directly define `resources` block and pass it to comp-dispatch deployment.