### PR TITLE
DEVOPS-2348 Trigger notification to circleci

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -48,7 +48,7 @@ type NotificationsSpec struct {
 	Pagerdutyteam string `json:"pagerdutyteam,omitempty"`
 	// CircleCi webhook for triggering Regression Test suite on QA tenants - DEVOPS-2348
 	// +optional
-	CircleciRegressionTestWebhook bool `json:"circleciRegressionTestWebhook,omitempty"`
+	CircleciRegressionWebhook bool `json:"circleciRegressionWebhook,omitempty"`
 }
 
 // DatabaseSpec defines database-related configuration.
@@ -311,7 +311,7 @@ type NotificationStatus struct {
 	HwAuxVersion string `json:"hwAuxVersion,omitempty"`
 	// Circleci Regression test webhook status
 	// +optional
-	CircleciRegressionTestWebhook string `json:"circleciRegressionTestWebhook,omitempty"`
+	CircleciRegressionWebhook string `json:"circleciRegressionWebhook,omitempty"`
 }
 
 // MIVStatus is the output information for the Manual Identity Verification system.

--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -46,6 +46,9 @@ type NotificationsSpec struct {
 	DeploymentStatusUrl string `json:"deploymentStatusUrl,omitempty"`
 	// Name of pagerduty team. Team will be paged for all critical alerts
 	Pagerdutyteam string `json:"pagerdutyteam,omitempty"`
+	// CircleCi webhook for triggering Regression Test suite on QA tenants - DEVOPS-2348
+	// +optional
+	CircleciRegressionTestWebhook bool `json:"circleciRegressionTestWebhook,omitempty"`
 }
 
 // DatabaseSpec defines database-related configuration.
@@ -306,6 +309,9 @@ type NotificationStatus struct {
 	// The last version notification posted for HwAux deploy.
 	// +optional
 	HwAuxVersion string `json:"hwAuxVersion,omitempty"`
+	// Circleci Regression test webhook status
+	// +optional
+	CircleciRegressionTestWebhook string `json:"circleciRegressionTestWebhook,omitempty"`
 }
 
 // MIVStatus is the output information for the Manual Identity Verification system.

--- a/pkg/controller/summon/components/notification.go
+++ b/pkg/controller/summon/components/notification.go
@@ -115,7 +115,7 @@ func (c *realDeployStatusClient) PostStatus(url string, name string, env string,
 // Interface for Circleci client
 //go:generate moq -out zz_generated.mock_circleciclient_test.go . CircleCiClient
 type CircleCiClient interface {
-	TriggerRegressionSuite(instanceName string) string
+	TriggerRegressionSuite(instanceName string, version string) string
 }
 
 type realCircleCiClient struct{}

--- a/pkg/controller/summon/components/notification.go
+++ b/pkg/controller/summon/components/notification.go
@@ -211,8 +211,8 @@ func (c *notificationComponent) handleSuccess(instance *summonv1beta1.SummonPlat
 
 	// Trigger CircleCi Regression Test Webhook, if set true
 	webhookStatus := "Triggered"
-	if instance.Spec.Notifications.CircleciRegressionTestWebhook {
-		apiKey := os.Getenv("CIRCLECI_TEST_API_KEY")
+	if instance.Spec.Notifications.CircleciRegressionWebhook {
+		apiKey := os.Getenv("CIRCLECI_API_KEY")
 		if apiKey != "" {
 			postData := map[string]interface{}{
 				"branch": "master",
@@ -227,7 +227,7 @@ func (c *notificationComponent) handleSuccess(instance *summonv1beta1.SummonPlat
 				webhookStatus = fmt.Sprintf("%s", err)
 			}
 		} else {
-			webhookStatus = "CIRCLECI_TEST_API_KEY environment variable not defined"
+			webhookStatus = "CIRCLECI_API_KEY environment variable not defined"
 		}
 	}
 
@@ -240,8 +240,8 @@ func (c *notificationComponent) handleSuccess(instance *summonv1beta1.SummonPlat
 			instance.Status.Notification.BusinessPortalVersion = instance.Spec.BusinessPortal.Version
 			instance.Status.Notification.HwAuxVersion = instance.Spec.HwAux.Version
 			instance.Status.Notification.TripShareVersion = instance.Spec.TripShare.Version
-			if instance.Spec.Notifications.CircleciRegressionTestWebhook {
-				instance.Status.Notification.CircleciRegressionTestWebhook = webhookStatus
+			if instance.Spec.Notifications.CircleciRegressionWebhook {
+				instance.Status.Notification.CircleciRegressionWebhook = webhookStatus
 			}
 			return nil
 		}}, nil

--- a/pkg/controller/summon/components/notification.go
+++ b/pkg/controller/summon/components/notification.go
@@ -112,10 +112,41 @@ func (c *realDeployStatusClient) PostStatus(url string, name string, env string,
 	return nil
 }
 
+// Interface for Circleci client
+//go:generate moq -out zz_generated.mock_circleciclient_test.go . CircleCiClient
+type CircleCiClient interface {
+	TriggerRegressionSuite(instanceName string) string
+}
+
+type realCircleCiClient struct{}
+
+// Real implementation of CallCircleciAPI
+func (c *realCircleCiClient) TriggerRegressionSuite(instanceName string) string {
+	apiKey := os.Getenv("CIRCLECI_API_KEY")
+	if apiKey != "" {
+		postData := map[string]interface{}{
+			"branch": "master",
+			"parameters": map[string]interface{}{
+				"deployment-regression-tests": true,
+				"framework-tests":             false,
+				"tenant-name":                 instanceName,
+			},
+		}
+		err := utils.CallCircleCiWebhook("https://circleci.com/api/v2/project/github/Ridecell/Ridecell_qa_automation/pipeline", apiKey, postData)
+		if err != nil {
+			return fmt.Sprintf("%s", err)
+		}
+	} else {
+		return "CIRCLECI_API_KEY environment variable not defined"
+	}
+	return "Success"
+}
+
 type notificationComponent struct {
 	slackClient        SlackClient
 	deployStatusClient DeployStatusClient
 	dupCache           sync.Map
+	circleciClient     CircleCiClient
 }
 
 func NewNotification() *notificationComponent {
@@ -128,6 +159,7 @@ func NewNotification() *notificationComponent {
 	return &notificationComponent{
 		slackClient:        &realSlackClient{client: slackClient},
 		deployStatusClient: &realDeployStatusClient{},
+		circleciClient:     &realCircleCiClient{},
 	}
 }
 
@@ -137,6 +169,10 @@ func (c *notificationComponent) InjectSlackClient(client SlackClient) {
 
 func (c *notificationComponent) InjectDeployStatusClient(client DeployStatusClient) {
 	c.deployStatusClient = client
+}
+
+func (c *notificationComponent) InjectCircleCiClient(client CircleCiClient) {
+	c.circleciClient = client
 }
 
 func (_ *notificationComponent) WatchTypes() []runtime.Object {
@@ -210,25 +246,9 @@ func (c *notificationComponent) handleSuccess(instance *summonv1beta1.SummonPlat
 	}
 
 	// Trigger CircleCi Regression Test Webhook, if set true
-	webhookStatus := "Triggered"
+	var webhookStatus string
 	if instance.Spec.Notifications.CircleciRegressionWebhook {
-		apiKey := os.Getenv("CIRCLECI_API_KEY")
-		if apiKey != "" {
-			postData := map[string]interface{}{
-				"branch": "master",
-				"parameters": map[string]interface{}{
-					"deployment-regression-tests": true,
-					"framework-tests":false,
-					"tenant-name": instance.Name,
-				},
-			}
-			err := utils.CallCircleCiWebhook("https://circleci.com/api/v2/project/github/Ridecell/Ridecell_qa_automation/pipeline", apiKey, postData)
-			if err != nil {
-				webhookStatus = fmt.Sprintf("%s", err)
-			}
-		} else {
-			webhookStatus = "CIRCLECI_API_KEY environment variable not defined"
-		}
+		webhookStatus = c.circleciClient.TriggerRegressionSuite(instance.Name)
 	}
 
 	// no errors, update notification statuses.

--- a/pkg/controller/summon/components/notification.go
+++ b/pkg/controller/summon/components/notification.go
@@ -222,7 +222,7 @@ func (c *notificationComponent) handleSuccess(instance *summonv1beta1.SummonPlat
 					"tenant-name": instance.Name,
 				},
 			}
-			err = utils.callCircleCiWebhook("https://circleci.com/api/v2/project/github/Ridecell/Ridecell_qa_automation/pipeline", apiKey, postData)
+			err := utils.CallCircleCiWebhook("https://circleci.com/api/v2/project/github/Ridecell/Ridecell_qa_automation/pipeline", apiKey, postData)
 			if err != nil {
 				webhookStatus = fmt.Sprintf("%s", err)
 			}

--- a/pkg/controller/summon/components/notification_test.go
+++ b/pkg/controller/summon/components/notification_test.go
@@ -321,5 +321,7 @@ var _ = Describe("SummonPlatform Notification Component", func() {
 			Expect(post4.In2.Fallback).To(Equal("foo.ridecell.us has error: You have no chance to survive"))
 			Expect(mockedDeployStatusClient.PostStatusCalls()).To(HaveLen(0))
 		})
+
+		// TODO: Add Circleci Webhook test cases
 	})
 })

--- a/pkg/utils/circleci_webhook.go
+++ b/pkg/utils/circleci_webhook.go
@@ -46,7 +46,7 @@ func CallCircleCiWebhook(apiUrl string, apiKey string, data map[string]interface
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 201 {
-		return errors.Errorf("CircleCi Regression Test webhook response code HTTP %d", resp.StatusCode)
+		return errors.Errorf("CircleCi Regression webhook response code HTTP %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/utils/circleci_webhook.go
+++ b/pkg/utils/circleci_webhook.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 )
 
-func callCircleCiWebhook(apiUrl string, apiKey string, data map[string]interface{}) error {
+func CallCircleCiWebhook(apiUrl string, apiKey string, data map[string]interface{}) error {
 
 	payloadBytes, err := json.Marshal(data)
 	if err != nil {

--- a/pkg/utils/circleci_webhook.go
+++ b/pkg/utils/circleci_webhook.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/Ridecell/ridecell-operator/pkg/errors"
+	"net/http"
+)
+
+func callCircleCiWebhook(apiUrl string, apiKey string, data map[string]interface{}) error {
+
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	body := bytes.NewReader(payloadBytes)
+	req, err := http.NewRequest("POST", apiUrl, body)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(apiKey, "")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-attribution-login", "ridecell-operator")
+	req.Header.Set("x-attribution-actor-id", "ridecell-operator")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		return errors.Errorf("CircleCi Regression Test webhook response code HTTP %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
Added circleci regression test suite webhook - it will trigger tests after successful summon deployment.
Test cases yet to be added.