### PR TITLE
CORE-1558 Enable JSON Logging on all Production ENVs

### DIFF
--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -262,9 +262,8 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		gatewayEnv = "master"
 	}
 
-	if instance.Spec.Environment != "prod" {
-		defBoolVal("ENABLE_JSON_LOGGING", true)
-	}
+	// Set JSON Logging globally if not already set.
+	defBoolVal("ENABLE_JSON_LOGGING", true)
 
 	// Set debug to false globally if not already set.
 	defBoolVal("DEBUG", false)


### PR DESCRIPTION
Related to #284 

The proposed plan:

1. ridecell-operator defaults to TRUE for all but prod.
2. ENABLE_JSON_LOGGING to be set to True on Prod instances during future deploys (making sure Customer Support team is aware)
3. A PR to ridecell/summon-platform will be made to remove ENABLE_JSON_LOGGING from settings. Turning it on everywhere and without even checking config values. So no turning it off.
4. A follow-up PR to ridecell-operator to clean and remove ENABLE_JSON_LOGGING
5. We remove the references to ENABLE_JSON_LOGGING from ridecell-operator and from kuberenetes-summon