### PR TITLE
DEVOPS-2336 cert manager upgrade v0.11

### DIFF
--- a/pkg/controller/ridecellingress/components/ridecellingress.go
+++ b/pkg/controller/ridecellingress/components/ridecellingress.go
@@ -62,8 +62,8 @@ func (comp *ridecellingressComponent) Reconcile(ctx *components.ComponentContext
 	if status, ok := instance.Annotations["kubernetes.io/tls-acme"]; !ok || len(status) == 0 {
 		instance.Annotations["kubernetes.io/tls-acme"] = ingressv1beta1.TLS_ACME
 	}
-	if issuer, ok := instance.Annotations["certmanager.k8s.io/cluster-issuer"]; !ok || len(issuer) == 0 {
-		instance.Annotations["certmanager.k8s.io/cluster-issuer"] = ingressv1beta1.ClusterIssuer
+	if issuer, ok := instance.Annotations["cert-manager.io/cluster-issuer"]; !ok || len(issuer) == 0 {
+		instance.Annotations["cert-manager.io/cluster-issuer"] = ingressv1beta1.ClusterIssuer
 	}
 
 	//Iterating over each Rule to check hostnames

--- a/pkg/controller/ridecellingress/components/ridecellingress_test.go
+++ b/pkg/controller/ridecellingress/components/ridecellingress_test.go
@@ -89,7 +89,7 @@ var _ = Describe("RidecellIngress Component", func() {
 		// Check for custom annotation
 		Expect(target.Annotations).To(HaveKeyWithValue("abc.io/ping", "pong"))
 		// below annotation should be added automatically with default value as its not present in instance definition
-		Expect(target.Annotations).To(HaveKeyWithValue("certmanager.k8s.io/cluster-issuer", "letsencrypt-prod"))
+		Expect(target.Annotations).To(HaveKeyWithValue("cert-manager.io/cluster-issuer", "letsencrypt-prod"))
 	})
 
 	It("creates an RidecellIngress object without annotations", func() {
@@ -106,7 +106,7 @@ var _ = Describe("RidecellIngress Component", func() {
 		// Check for annotations and its values on target
 		Expect(target.Annotations).To(HaveKeyWithValue("kubernetes.io/ingress.class", "traefik"))
 		Expect(target.Annotations).To(HaveKeyWithValue("kubernetes.io/tls-acme", "true"))
-		Expect(target.Annotations).To(HaveKeyWithValue("certmanager.k8s.io/cluster-issuer", "letsencrypt-prod"))
+		Expect(target.Annotations).To(HaveKeyWithValue("cert-manager.io/cluster-issuer", "letsencrypt-prod"))
 	})
 
 	It("creates an RidecellIngress object with no required labels", func() {

--- a/pkg/controller/ridecellingress/controller_test.go
+++ b/pkg/controller/ridecellingress/controller_test.go
@@ -93,7 +93,7 @@ var _ = Describe("ridecellingress controller", func() {
 		// Check for custom annotation
 		Expect(target.Annotations).To(HaveKeyWithValue("abc.io/ping", "pong"))
 		// below annotation should be added automatically with default value as its not present in instance definition
-		Expect(target.Annotations).To(HaveKeyWithValue("certmanager.k8s.io/cluster-issuer", "letsencrypt-prod"))
+		Expect(target.Annotations).To(HaveKeyWithValue("cert-manager.io/cluster-issuer", "letsencrypt-prod"))
 	})
 
 	It("Creates RidecellIngress kind with invalid hostname", func() {

--- a/pkg/controller/summon/templates/helpers/ingress.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/ingress.yml.tpl
@@ -14,7 +14,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 {{ block "extraAnnotations" . }}{{ end }}
 spec:
   rules:


### PR DESCRIPTION
- changed all references of ` certmanager.k8s.io` to `cert-manager.io`