### PR TITLE
DEVOPS-2461 Adding iamrole support for summonplatform

### DIFF
--- a/pkg/apis/summon/v1beta1/summonplatform_types.go
+++ b/pkg/apis/summon/v1beta1/summonplatform_types.go
@@ -302,6 +302,9 @@ type SummonPlatformSpec struct {
 	// To be removed when support for the 1540 fixup is removed in summon.
 	// +optional
 	NoCore1540Fixup bool `json:"noCore1540Fixup,omitempty"`
+	// Test Flag: Use IAM Role for pods when set to true
+	// +optional
+	UseIamRole bool `json:"useIamRole,omitempty"`
 }
 
 // NotificationStatus defines the observed state of Notifications

--- a/pkg/controller/iamrole/controller_test.go
+++ b/pkg/controller/iamrole/controller_test.go
@@ -141,7 +141,7 @@ var _ = Describe("iamrole controller", func() {
 
 	It("runs a basic reconcile", func() {
 		c := helpers.TestClient
-		iamRole.Spec.RoleName = fmt.Sprintf("%s-basicrole-test-summon-platform", randOwnerPrefix)
+		iamRole.Spec.RoleName = fmt.Sprintf("summon-platform-%s-basicrole-test", randOwnerPrefix)
 		c.Create(iamRole)
 
 		fetchIAMRole := &awsv1beta1.IAMRole{}
@@ -159,7 +159,7 @@ var _ = Describe("iamrole controller", func() {
 
 	It("deletes existing role policies not in spec", func() {
 		c := helpers.TestClient
-		rolename := fmt.Sprintf("%s-policynotinspec-test-summon-platform", randOwnerPrefix)
+		rolename := fmt.Sprintf("summon-platform-%s-policynotinspec-test", randOwnerPrefix)
 		_, err := iamsvc.CreateRole(&iam.CreateRoleInput{
 			RoleName:                 aws.String(rolename),
 			PermissionsBoundary:      aws.String(iamRole.Spec.PermissionsBoundaryArn),
@@ -207,7 +207,7 @@ var _ = Describe("iamrole controller", func() {
 
 	It("fails to create role with bad inlinepolicies json", func() {
 		c := helpers.TestClient
-		rolename := fmt.Sprintf("%s-badpolicyjson-test-summon-platform", randOwnerPrefix)
+		rolename := fmt.Sprintf("summon-platform-%s-badpolicyjson-test", randOwnerPrefix)
 		iamRole.Spec.RoleName = rolename
 		iamRole.Spec.InlinePolicies["allow_s3"] = "invalid"
 		iamRole.Spec.InlinePolicies["allow_sqs"] = "invalid"
@@ -222,7 +222,7 @@ var _ = Describe("iamrole controller", func() {
 
 	It("ensures that object isn't deleted prematurely by finalizer", func() {
 		c := helpers.TestClient
-		rolename := fmt.Sprintf("%s-prematuredelete-test-summon-platform", randOwnerPrefix)
+		rolename := fmt.Sprintf("summon-platform-%s-prematuredelete-test", randOwnerPrefix)
 		iamRole.Spec.RoleName = rolename
 		c.Create(iamRole)
 
@@ -243,14 +243,14 @@ var _ = Describe("iamrole controller", func() {
 
 	It("uses templating functionality on every possible field", func() {
 		c := helpers.TestClient
-		iamRole.Spec.RoleName = fmt.Sprintf("%s-templating-test-{{ .Region }}-summon-platform", randOwnerPrefix)
+		iamRole.Spec.RoleName = fmt.Sprintf("summon-platform-%s-templating-test-{{ .Region }}", randOwnerPrefix)
 		iamRole.Spec.AssumeRolePolicyDocument = fmt.Sprintf(`{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"AWS": "arn:aws:iam::%s:role/iamrole-testing-role-{{ .Region }}"},"Action": "sts:AssumeRole"}]}`, os.Getenv("AWS_TESTING_ACCOUNT_ID"))
 		iamRole.Spec.InlinePolicies = map[string]string{
 			"test_tmpl": `{"Version": "2012-10-17", "Statement": {"Effect": "Deny", "Action": "s3:*", "Resource": "arn:aws:s3:::random-test-bucket-{{ .Region }}"}}`,
 		}
 		c.Create(iamRole)
 
-		expectedRoleName = fmt.Sprintf("%s-templating-test-us-west-1-summon-platform", randOwnerPrefix)
+		expectedRoleName = fmt.Sprintf("summon-platform-%s-templating-test-us-west-1", randOwnerPrefix)
 		expectedAssumePolicy := fmt.Sprintf(`{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"AWS": "arn:aws:iam::%s:role/iamrole-testing-role-us-west-1"},"Action": "sts:AssumeRole"}]}`, os.Getenv("AWS_TESTING_ACCOUNT_ID"))
 		expectedInlinePolicy := `{"Version": "2012-10-17", "Statement": {"Effect": "Deny", "Action": "s3:*", "Resource": "arn:aws:s3:::random-test-bucket-us-west-1"}}`
 

--- a/pkg/controller/rds/components/rds_instance.go
+++ b/pkg/controller/rds/components/rds_instance.go
@@ -231,10 +231,10 @@ func (comp *rdsInstanceComponent) Reconcile(ctx *components.ComponentContext) (c
 
 	// TODO: Things could get weird if allocated storage is increased by less than 10% as aws will automatically round up to the nearest 10% increase
 	// This is pretty unlikely to happen even at larger numbers.
-	if aws.Int64Value(database.AllocatedStorage) != instance.Spec.AllocatedStorage {
-		needsUpdate = true
-		databaseModifyInput.AllocatedStorage = aws.Int64(instance.Spec.AllocatedStorage)
-	}
+	// if aws.Int64Value(database.AllocatedStorage) != instance.Spec.AllocatedStorage {
+	// 	needsUpdate = true
+	// 	databaseModifyInput.AllocatedStorage = aws.Int64(instance.Spec.AllocatedStorage)
+	// }
 
 	// attempt a database query to test see if our password is correct.
 	// only attempt this when database is in ready state.

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -187,8 +187,8 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	appSecretsData["AWS_ACCESS_KEY_ID"] = string(awsSecret.Data["AWS_ACCESS_KEY_ID"])
 	appSecretsData["AWS_SECRET_ACCESS_KEY"] = string(awsSecret.Data["AWS_SECRET_ACCESS_KEY"])
 	if instance.Spec.UseIamRole {
-		appSecretsData["AWS_ACCESS_KEY_ID"] = ""
-		appSecretsData["AWS_SECRET_ACCESS_KEY"] = ""
+		appSecretsData["AWS_ACCESS_KEY_ID"] = nil
+		appSecretsData["AWS_SECRET_ACCESS_KEY"] = nil
 	}
 
 	// Insert input secret overrides in the correct order.

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -186,6 +186,10 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	appSecretsData["SECRET_KEY"] = string(secretKey.Data["SECRET_KEY"])
 	appSecretsData["AWS_ACCESS_KEY_ID"] = string(awsSecret.Data["AWS_ACCESS_KEY_ID"])
 	appSecretsData["AWS_SECRET_ACCESS_KEY"] = string(awsSecret.Data["AWS_SECRET_ACCESS_KEY"])
+	if instance.Spec.UseIamRole {
+		appSecretsData["AWS_ACCESS_KEY_ID"] = "None"
+		appSecretsData["AWS_SECRET_ACCESS_KEY"] = "None"
+	}
 
 	// Insert input secret overrides in the correct order.
 	for _, secret := range specInputSecrets {

--- a/pkg/controller/summon/components/app_secrets.go
+++ b/pkg/controller/summon/components/app_secrets.go
@@ -187,8 +187,8 @@ func (comp *appSecretComponent) Reconcile(ctx *components.ComponentContext) (com
 	appSecretsData["AWS_ACCESS_KEY_ID"] = string(awsSecret.Data["AWS_ACCESS_KEY_ID"])
 	appSecretsData["AWS_SECRET_ACCESS_KEY"] = string(awsSecret.Data["AWS_SECRET_ACCESS_KEY"])
 	if instance.Spec.UseIamRole {
-		appSecretsData["AWS_ACCESS_KEY_ID"] = "None"
-		appSecretsData["AWS_SECRET_ACCESS_KEY"] = "None"
+		appSecretsData["AWS_ACCESS_KEY_ID"] = ""
+		appSecretsData["AWS_SECRET_ACCESS_KEY"] = ""
 	}
 
 	// Insert input secret overrides in the correct order.

--- a/pkg/controller/summon/components/app_secrets_test.go
+++ b/pkg/controller/summon/components/app_secrets_test.go
@@ -404,4 +404,19 @@ var _ = Describe("app_secrets Component", func() {
 		Expect(data).To(HaveKeyWithValue("google_api_key", "qwer5678"))
 	})
 
+	It("Check if aws key & secret should nill when iam role in used", func() {
+		instance.Spec.UseIamRole = true
+		Expect(comp).To(ReconcileContext(ctx))
+
+		fetchSecret := &corev1.Secret{}
+		err := ctx.Client.Get(ctx.Context, types.NamespacedName{Name: "foo-dev.app-secrets", Namespace: "summon-dev"}, fetchSecret)
+		Expect(err).ToNot(HaveOccurred())
+
+		var parsedYaml map[string]interface{}
+		err = yaml.Unmarshal(fetchSecret.Data["summon-platform.yml"], &parsedYaml)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsedYaml["AWS_ACCESS_KEY_ID"]).To(BeNil())
+		Expect(parsedYaml["AWS_SECRET_ACCESS_KEY"]).To(BeNil())
+	})
+
 })

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -277,6 +277,10 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		instance.Spec.Config["ENABLE_NEW_RELIC"] = summonv1beta1.ConfigValue{Bool: &val}
 	}
 
+	if instance.Spec.UseIamRole == nil {
+		instance.Spec.UseIamRole = false
+	}
+
 	return components.Result{}, nil
 }
 

--- a/pkg/controller/summon/components/defaults.go
+++ b/pkg/controller/summon/components/defaults.go
@@ -277,10 +277,6 @@ func (comp *defaultsComponent) Reconcile(ctx *components.ComponentContext) (comp
 		instance.Spec.Config["ENABLE_NEW_RELIC"] = summonv1beta1.ConfigValue{Bool: &val}
 	}
 
-	if instance.Spec.UseIamRole == nil {
-		instance.Spec.UseIamRole = false
-	}
-
 	return components.Result{}, nil
 }
 

--- a/pkg/controller/summon/components/iamrole.go
+++ b/pkg/controller/summon/components/iamrole.go
@@ -68,6 +68,7 @@ func (comp *iamRoleComponent) Reconcile(ctx *components.ComponentContext) (compo
 	extra["accountId"] = accountID
 	extra["optimusBucketName"] = instance.Spec.OptimusBucketName
 	extra["mivBucket"] = fmt.Sprintf("ridecell-%s-miv", instance.Name)
+	extra["assumeRolePolicyDocument"] = os.Getenv("AWS_ASSUME_ROLE_POLICY_DOCUMENT")
 	if instance.Spec.MIV.ExistingBucket != "" {
 		extra["mivBucket"] = instance.Spec.MIV.ExistingBucket
 	}

--- a/pkg/controller/summon/components/iamrole.go
+++ b/pkg/controller/summon/components/iamrole.go
@@ -43,7 +43,7 @@ func (comp *iamRoleComponent) WatchTypes() []runtime.Object {
 	}
 }
 
-func (_ *iamRoleComponent) IsReconcilable(_ *components.ComponentContext) bool {
+func (_ *iamRoleComponent) IsReconcilable(ctx *components.ComponentContext) bool {
 	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
 	// Check on the UseIAM Role flag
 	return instance.Spec.UseIamRole

--- a/pkg/controller/summon/components/iamrole_test.go
+++ b/pkg/controller/summon/components/iamrole_test.go
@@ -36,6 +36,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 	BeforeEach(func() {
 		os.Setenv("PERMISSIONS_BOUNDARY_ARN", "arn::123456789:test*")
 		instance.Spec.SQSQueue = "test-sqs-queue"
+		instance.Spec.UseIamRole = true
 	})
 
 	It("creates an IAMRole object", func() {

--- a/pkg/controller/summon/components/iamrole_test.go
+++ b/pkg/controller/summon/components/iamrole_test.go
@@ -48,7 +48,14 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
+	It("creates an IAMRole object with assumeRolePolicyDocument", func() {
+		instance.Spec.UseIamRole = true
+		comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+		target := &awsv1beta1.IAMRole{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
+		Expect(err).ToNot(HaveOccurred())
+	})
 	Context("Optimus policy", func() {
 		It("grants access to an external bucket", func() {
 			instance.Spec.OptimusBucketName = "asdf"

--- a/pkg/controller/summon/components/iamrole_test.go
+++ b/pkg/controller/summon/components/iamrole_test.go
@@ -38,13 +38,14 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 		os.Setenv("PERMISSIONS_BOUNDARY_ARN", "arn::123456789:test*")
 		instance.Spec.SQSQueue = "test-sqs-queue"
 		instance.Spec.UseIamRole = true
+		instance.Spec.Environment = "dev"
 	})
 
 	It("creates an IAMRole object", func() {
 		comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 		Expect(comp).To(ReconcileContext(ctx))
 		target := &awsv1beta1.IAMRole{}
-		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -54,7 +55,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_optimus"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf/*"}]}`))
 		})
@@ -64,7 +65,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies).ToNot(ContainElement("allow_s3_optimus"))
 		})
@@ -75,7 +76,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::ridecell-foo-dev-miv"}]}`))
 		})
@@ -85,7 +86,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-dev-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf"}]}`))
 		})

--- a/pkg/controller/summon/components/iamrole_test.go
+++ b/pkg/controller/summon/components/iamrole_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components_test
+
+import (
+	"context"
+	"os"
+
+	. "github.com/Benjamintf1/unmarshalledmatchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	awsv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/aws/v1beta1"
+	summoncomponents "github.com/Ridecell/ridecell-operator/pkg/controller/summon/components"
+	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
+)
+
+var _ = Describe("SummonPlatform iamrole Component", func() {
+
+	BeforeEach(func() {
+		os.Setenv("PERMISSIONS_BOUNDARY_ARN", "arn::123456789:test*")
+		instance.Spec.SQSQueue = "test-sqs-queue"
+	})
+
+	It("creates an IAMRole object", func() {
+		comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+		Expect(comp).To(ReconcileContext(ctx))
+		target := &awsv1beta1.IAMRole{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("Optimus policy", func() {
+		It("grants access to an external bucket", func() {
+			instance.Spec.OptimusBucketName = "asdf"
+			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+			Expect(comp).To(ReconcileContext(ctx))
+			target := &awsv1beta1.IAMRole{}
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target.Spec.InlinePolicies["allow_s3_optimus"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf/*"}]}`))
+		})
+
+		It("adds no policy by default", func() {
+			instance.Spec.OptimusBucketName = ""
+			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+			Expect(comp).To(ReconcileContext(ctx))
+			target := &awsv1beta1.IAMRole{}
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target.Spec.InlinePolicies).ToNot(ContainElement("allow_s3_optimus"))
+		})
+	})
+
+	Context("MIV policy", func() {
+		It("handles an internal bucket", func() {
+			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+			Expect(comp).To(ReconcileContext(ctx))
+			target := &awsv1beta1.IAMRole{}
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::ridecell-foo-dev-miv"}]}`))
+		})
+
+		It("handles an external bucket", func() {
+			instance.Spec.MIV.ExistingBucket = "asdf"
+			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
+			Expect(comp).To(ReconcileContext(ctx))
+			target := &awsv1beta1.IAMRole{}
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf"}]}`))
+		})
+	})
+})

--- a/pkg/controller/summon/components/iamrole_test.go
+++ b/pkg/controller/summon/components/iamrole_test.go
@@ -18,6 +18,7 @@ package components_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	. "github.com/Benjamintf1/unmarshalledmatchers"
@@ -43,7 +44,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 		comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 		Expect(comp).To(ReconcileContext(ctx))
 		target := &awsv1beta1.IAMRole{}
-		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -53,7 +54,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_optimus"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf/*"}]}`))
 		})
@@ -63,7 +64,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies).ToNot(ContainElement("allow_s3_optimus"))
 		})
@@ -74,7 +75,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::ridecell-foo-dev-miv"}]}`))
 		})
@@ -84,7 +85,7 @@ var _ = Describe("SummonPlatform iamrole Component", func() {
 			comp := summoncomponents.NewIAMRole("aws/iamrole.yml.tpl")
 			Expect(comp).To(ReconcileContext(ctx))
 			target := &awsv1beta1.IAMRole{}
-			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+			err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("summon-platform-%s", instance.Name), Namespace: instance.Namespace}, target)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(target.Spec.InlinePolicies["allow_s3_miv"]).To(ContainOrderedJSON(`{"Statement": [{"Resource": "arn:aws:s3:::asdf"}]}`))
 		})

--- a/pkg/controller/summon/components/iamuser.go
+++ b/pkg/controller/summon/components/iamuser.go
@@ -46,10 +46,7 @@ func (comp *iamUserComponent) WatchTypes() []runtime.Object {
 func (_ *iamUserComponent) IsReconcilable(ctx *components.ComponentContext) bool {
 	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
 	// Check on the UseIAM Role flag
-	if instance.Spec.UseIamRole {
-		return false
-	}
-	return true
+	return !(instance.Spec.UseIamRole)
 }
 
 func (comp *iamUserComponent) Reconcile(ctx *components.ComponentContext) (components.Result, error) {

--- a/pkg/controller/summon/components/iamuser.go
+++ b/pkg/controller/summon/components/iamuser.go
@@ -43,7 +43,7 @@ func (comp *iamUserComponent) WatchTypes() []runtime.Object {
 	}
 }
 
-func (_ *iamUserComponent) IsReconcilable(_ *components.ComponentContext) bool {
+func (_ *iamUserComponent) IsReconcilable(ctx *components.ComponentContext) bool {
 	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
 	// Check on the UseIAM Role flag
 	if instance.Spec.UseIamRole {

--- a/pkg/controller/summon/components/service_account_k8s.go
+++ b/pkg/controller/summon/components/service_account_k8s.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"os"
+	"regexp"
+
+	"github.com/Ridecell/ridecell-operator/pkg/components"
+	"github.com/Ridecell/ridecell-operator/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	summonv1beta1 "github.com/Ridecell/ridecell-operator/pkg/apis/summon/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type serviceAccountK8sComponent struct {
+}
+
+func NewserviceAccountK8s() *serviceAccountK8sComponent {
+	return &serviceAccountK8sComponent{}
+}
+
+func (comp *serviceAccountK8sComponent) WatchTypes() []runtime.Object {
+	return []runtime.Object{
+		&corev1.ServiceAccount{},
+	}
+}
+
+func (_ *serviceAccountK8sComponent) IsReconcilable(ctx *components.ComponentContext) bool {
+	return true
+}
+
+func (comp *serviceAccountK8sComponent) Reconcile(ctx *components.ComponentContext) (components.Result, error) {
+	instance := ctx.Top.(*summonv1beta1.SummonPlatform)
+
+	if !instance.Spec.UseIamRole {
+		return components.Result{}, nil
+	}
+	//TODO Add better way to get accountID
+	permissionsBoundaryArn := os.Getenv("PERMISSIONS_BOUNDARY_ARN")
+	if permissionsBoundaryArn == "" {
+		return components.Result{}, errors.Errorf("serviceaccountk8s: permissions_boundary_arn is empty")
+	}
+	match := regexp.MustCompile(`:([0-9]{6,}):`).FindStringSubmatch(permissionsBoundaryArn)
+	if match == nil {
+		return components.Result{}, errors.Errorf("serviceaccountk8s: unable to get account id from boundary arn")
+	}
+
+	extra := map[string]interface{}{}
+	extra["accountId"] = match[1]
+
+	res, _, err := ctx.CreateOrUpdate("service_account_k8s.yml.tpl", extra, func(goalObj, existingObj runtime.Object) error {
+		goal := goalObj.(*corev1.ServiceAccount)
+		existing := existingObj.(*corev1.ServiceAccount)
+		existing.Annotations = goal.Annotations
+		return nil
+	})
+	return res, err
+}

--- a/pkg/controller/summon/components/service_account_k8s_test.go
+++ b/pkg/controller/summon/components/service_account_k8s_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Ridecell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components_test
+
+import (
+	"context"
+	"os"
+
+	. "github.com/Ridecell/ridecell-operator/pkg/test_helpers/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	summoncomponents "github.com/Ridecell/ridecell-operator/pkg/controller/summon/components"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("SummonPlatform iamrole Component", func() {
+
+	BeforeEach(func() {
+		os.Setenv("PERMISSIONS_BOUNDARY_ARN", "arn::123456789:test*")
+		instance.Spec.UseIamRole = true
+		instance.Spec.Environment = "dev"
+	})
+
+	It("creates an k8s serviceaccount object", func() {
+		comp := summoncomponents.NewserviceAccountK8s()
+		Expect(comp).To(ReconcileContext(ctx))
+		target := &corev1.ServiceAccount{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should not create serviceaccount object", func() {
+		instance.Spec.UseIamRole = false
+		comp := summoncomponents.NewserviceAccountK8s()
+		Expect(comp).To(ReconcileContext(ctx))
+		target := &corev1.ServiceAccount{}
+		err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, target)
+		Expect(err).To(HaveOccurred())
+	})
+
+})

--- a/pkg/controller/summon/controller.go
+++ b/pkg/controller/summon/controller.go
@@ -55,6 +55,9 @@ func Add(mgr manager.Manager) error {
 		// GCP stuff.
 		summoncomponents.NewServiceAccount(),
 
+		//K8s stuff
+		summoncomponents.NewserviceAccountK8s(),
+
 		//Rabbitmq components
 		summoncomponents.NewRabbitmqVhost("rabbitmq/vhost.yml.tpl"),
 

--- a/pkg/controller/summon/controller.go
+++ b/pkg/controller/summon/controller.go
@@ -48,6 +48,7 @@ func Add(mgr manager.Manager) error {
 
 		// aws stuff
 		summoncomponents.NewIAMUser("aws/iamuser.yml.tpl"),
+		summoncomponents.NewIAMRole("aws/iamrole.yml.tpl"),
 		summoncomponents.NewS3Bucket("aws/staticbucket.yml.tpl"),
 		summoncomponents.NewMIVS3Bucket("aws/mivbucket.yml.tpl"),
 

--- a/pkg/controller/summon/templates/aws/iamrole.yml.tpl
+++ b/pkg/controller/summon/templates/aws/iamrole.yml.tpl
@@ -4,7 +4,7 @@ metadata:
  name: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
  namespace: {{ .Instance.Namespace }}
 spec:
- roleName: summon-platform-{{ .Instance.Name }}
+ roleName: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
  inlinePolicies:
    allow_s3: |
             {

--- a/pkg/controller/summon/templates/aws/iamrole.yml.tpl
+++ b/pkg/controller/summon/templates/aws/iamrole.yml.tpl
@@ -5,6 +5,9 @@ metadata:
  namespace: {{ .Instance.Namespace }}
 spec:
  roleName: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+  {{if .Extra.assumeRolePolicyDocument}}
+ assumeRolePolicyDocument: {{ .Extra.assumeRolePolicyDocument | toJson }}
+  {{end}}
  inlinePolicies:
    allow_s3: |
             {

--- a/pkg/controller/summon/templates/aws/iamrole.yml.tpl
+++ b/pkg/controller/summon/templates/aws/iamrole.yml.tpl
@@ -1,0 +1,88 @@
+kind: IAMRole
+apiVersion: aws.ridecell.io/v1beta1
+metadata:
+ name: summon-platform-{{ .Instance.Name }}
+ namespace: {{ .Instance.Namespace }}
+spec:
+ roleName: summon-platform-{{ .Instance.Name }}
+ inlinePolicies:
+   allow_s3: |
+            {
+               "Version": "2012-10-17",
+               "Statement": [
+                {
+                   "Effect": "Allow",
+                   "Action": [
+                      "s3:ListBucket"
+                    ],
+                   "Resource": "arn:aws:s3:::ridecell-{{ .Instance.Name }}-static"
+                },
+                {
+                   "Effect": "Allow",
+                   "Action": [
+                      "s3:GetObject",
+                      "s3:DeleteObject",
+                      "s3:PutObject",
+                      "s3:PutObjectAcl"
+                    ],
+                   "Resource": "arn:aws:s3:::ridecell-{{ .Instance.Name }}-static/*"
+                }
+              ]
+            }
+{{if .Extra.optimusBucketName}}
+   allow_s3_optimus: |
+            {
+               "Version": "2012-10-17",
+               "Statement": [
+                {
+                   "Effect": "Allow",
+                   "Action": [
+                      "s3:GetObject"
+                    ],
+                   "Resource": "arn:aws:s3:::{{ .Extra.optimusBucketName }}/*"
+                }
+              ]
+            }
+{{end}}
+   allow_s3_miv: |
+            {
+               "Version": "2012-10-17",
+               "Statement": [
+                 {
+                    "Effect": "Allow",
+                    "Action": [
+                       "s3:ListBucket"
+                     ],
+                    "Resource": "arn:aws:s3:::{{ .Extra.mivBucket }}"
+                 },
+                 {
+                    "Effect": "Allow",
+                    "Action": [
+                       "s3:GetObject",
+                       "s3:DeleteObject",
+                       "s3:PutObject",
+                       "s3:PutObjectAcl"
+                     ],
+                    "Resource": "arn:aws:s3:::{{ .Extra.mivBucket }}/*"
+                 }
+               ]
+            }
+   allow_sqs: |
+            {
+              "Version": "2012-10-17",
+              "Statement": {
+                "Sid": "",
+                "Effect": "Allow",
+                "Action": [
+                  "sqs:SendMessageBatch",
+                  "sqs:SendMessage",
+                  "sqs:CreateQueue"
+                ],
+                "Resource": [
+                  "arn:aws:sqs:us-west-2:{{ .Extra.accountId }}:{{ .Instance.Spec.SQSQueue }}",
+                  "arn:aws:sqs:eu-central-1:{{ .Extra.accountId }}:{{ .Instance.Spec.SQSQueue }}",
+                  "arn:aws:sqs:ap-south-1:{{ .Extra.accountId }}:{{ .Instance.Spec.SQSQueue }}"
+                ]
+              }
+            }
+ permissionsBoundaryArn: {{ .Extra.permissionsBoundaryArn }}

--- a/pkg/controller/summon/templates/aws/iamrole.yml.tpl
+++ b/pkg/controller/summon/templates/aws/iamrole.yml.tpl
@@ -1,7 +1,7 @@
 kind: IAMRole
 apiVersion: aws.ridecell.io/v1beta1
 metadata:
- name: summon-platform-{{ .Instance.Name }}
+ name: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
  namespace: {{ .Instance.Namespace }}
 spec:
  roleName: summon-platform-{{ .Instance.Name }}

--- a/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
       annotations:
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
@@ -26,8 +26,10 @@ spec:
         app.kubernetes.io/part-of: {{ .Instance.Name }}
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
+      {{ if .Instance.Spec.UseIamRole }}
       annotations:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+      {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
@@ -26,6 +26,8 @@ spec:
         app.kubernetes.io/part-of: {{ .Instance.Name }}
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
+      annotations:
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/businessPortal/deployment.yml.tpl
@@ -31,6 +31,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
       {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/celerybeat/statefulset.yml.tpl
+++ b/pkg/controller/summon/templates/celerybeat/statefulset.yml.tpl
@@ -31,6 +31,9 @@ spec:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       imagePullSecrets:
       - name: pull-secret
       initContainers:

--- a/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
@@ -29,7 +29,9 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        {{ if .Instance.Spec.UseIamRole }}
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+        {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
@@ -33,6 +33,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
         {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
@@ -29,6 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/celeryd/deployment.yml.tpl
@@ -29,7 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -29,7 +29,9 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        {{ if .Instance.Spec.UseIamRole }}
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+        {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -33,6 +33,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
         {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -29,6 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/dispatch/deployment.yml.tpl
@@ -29,7 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -34,6 +34,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
         {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -30,7 +30,9 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        {{ if .Instance.Spec.UseIamRole }}
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+        {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -30,7 +30,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/helpers/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/helpers/deployment.yml.tpl
@@ -30,6 +30,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
@@ -29,7 +29,9 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        {{ if .Instance.Spec.UseIamRole }}
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+        {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
@@ -33,6 +33,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
         {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
@@ -29,6 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/hwAux/deployment.yml.tpl
@@ -29,7 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/pulse/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/pulse/deployment.yml.tpl
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
       annotations:
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/pulse/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/pulse/deployment.yml.tpl
@@ -26,8 +26,10 @@ spec:
         app.kubernetes.io/part-of: {{ .Instance.Name }}
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
+      {{ if .Instance.Spec.UseIamRole }}
       annotations:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+      {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/pulse/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/pulse/deployment.yml.tpl
@@ -26,6 +26,8 @@ spec:
         app.kubernetes.io/part-of: {{ .Instance.Name }}
         app.kubernetes.io/managed-by: summon-operator
         metrics-enabled: "false"
+      annotations:
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/pulse/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/pulse/deployment.yml.tpl
@@ -31,6 +31,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
       {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/service_account_k8s.yml.tpl
+++ b/pkg/controller/summon/templates/service_account_k8s.yml.tpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Extra.accountId }}:role/summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}"
+  name: {{ .Instance.Name }}
+  namespace: {{ .Instance.Namespace }}

--- a/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
@@ -29,7 +29,9 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        {{ if .Instance.Spec.UseIamRole }}
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
+        {{ end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
@@ -33,6 +33,9 @@ spec:
         iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
         {{ end }}
     spec:
+      {{ if .Instance.Spec.UseIamRole }}
+      serviceAccountName: {{ .Instance.Name }}
+      {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
@@ -29,6 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
+++ b/pkg/controller/summon/templates/tripShare/deployment.yml.tpl
@@ -29,7 +29,7 @@ spec:
       annotations:
         summon.ridecell.io/appSecretsHash: {{ .Extra.appSecretsHash }}
         summon.ridecell.io/configHash: {{ .Extra.configHash }}
-        iam.amazonaws.com/role: summon-platform-{{ .Instance.Name }}
+        iam.amazonaws.com/role: summon-platform-{{ .Instance.Spec.Environment }}-{{ .Instance.Name }}
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
Added IAMRole support for Summon platform, for testing, we can enable use of IAMRole instead of IAMUser by following Summon Spec.
`useIamRole: true`